### PR TITLE
fix ag_stats for wwwadmin

### DIFF
--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -802,8 +802,7 @@ class AGDataAccess(object):
         # site_sampled, sample_date, sample_time, participant_name,
         #environment_sampled, notes
         results = self._sql.execute_proc_return_cursor('ag_stats', [])
-        col_names = self._get_col_names_from_cursor(results)
-        ag_stats = [dict(zip(col_names, row)) for row in results]
+        ag_stats = results.fetchall()
         results.close()
         return ag_stats
 


### PR DESCRIPTION
This procedure used to return a list of tuples (valuename, value) and these vaulenames don't correspond to column names so this function cant use the standard dict like everything else
