### PR TITLE
MAINT: Move sample overview text to locale

### DIFF
--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -30,6 +30,13 @@ _DB_ERROR = {
     'SIGNOFF': 'Thanks, <br /> The American Gut Team'
 }
 
+_PARTICIPANT_OVERVIEW = {
+    'COMPLETED_CONSENT': 'Completed consent',
+    'COMPLETED_SURVEY': 'Completed survey',
+    'SAMPLES_ASSIGNED': 'Samples assigned',
+    'OVERVIEW_FOR_PARTICPANT': 'Overview for participant'
+}
+
 _SAMPLE_OVERVIEW = {
     'BARCODE_RECEIVED': 'Sample %(barcode)s. This sample has been received by the sequencing center!',
     'DISPLAY_BARCODE': 'Sample %(barcode)s',
@@ -102,6 +109,7 @@ text_locale = {
     'error.html': _ERROR,
     'forgot_password.html': _FORGOT_PASSWORD,
     'help_request.html': _HELP_REQUEST,
+    'participant_overview.html': _PARTICIPANT_OVERVIEW,
     'sample_overview.html': _SAMPLE_OVERVIEW,
     'taxa_summary.html': _TAXA_SUMMARY,
     'construction.html': _CONSTRUCTION,

--- a/amgut/templates/participant_overview.html
+++ b/amgut/templates/participant_overview.html
@@ -1,5 +1,7 @@
 {% extends sitebase.html %}
 {% block content %}
+{% from amgut import text_locale %}
+{% set tl = text_locale['participant_overview.html'] %}
 
 <form action="survey1.html" method="post" id="edit_survey">
 
@@ -9,18 +11,18 @@
 
 </form>
 
-<h2>Overview for participant {{participant_name}}</h2>
+<h2>{% raw tl['OVERVIEW_FOR_PARTICPANT'] %} {{participant_name}}</h2>
 <div class="overview_wrapper">
     <div class="overview">
         <table class="list" id="survey" width="100%">
 {% if participant_type == 'human' %}
             <tr>
-                <td>Completed consent</td>
+                <td>{% raw tl['COMPLETED_CONSENT'] %}</td>
                 <td><img src="/static/img/icon-green-checkmark.png"/></td>
             </tr>
 {% end %}
             <tr>
-                <td>Completed survey
+                <td>{% raw tl['COMPLETED_SURVEY'] %}
 {% if participant_type == 'human' %}
                     (<a href="#" onclick="editHumanSurvey();">edit</a>)
 {% end %}
@@ -28,7 +30,7 @@
                 <td><img src="/static/img/icon-green-checkmark.png"/></td>
             </tr>
             <tr>
-                <td>Samples assigned</td>
+                <td>{% raw tl['SAMPLES_ASSIGNED'] %}</td>
                 <td>
                     <ul class="sample_list">
 


### PR DESCRIPTION
The text has been moved to the american_gut.py locale file.
