### PR TITLE
Fix wrongly-named variable

### DIFF
--- a/amgut/templates/help_request.html
+++ b/amgut/templates/help_request.html
@@ -1,7 +1,7 @@
 {% extends sitebase.html %}
 {% block content %}
 {% from amgut import text_locale %}
-{% set tl = tl['help_request.html'] %}
+{% set tl = text_locale['help_request.html'] %}
 <h2>{% raw tl['CONTACT_HEADER'] %}</h2>
 <h4>{% raw tl['RESPONSE_TIMING'] %}</h4>
 


### PR DESCRIPTION
Single line change because a variable name was wrong for the contact us page.
