### PR TITLE
BUG: Add handler for non-existant static file

### DIFF
--- a/amgut/handlers/base_handlers.py
+++ b/amgut/handlers/base_handlers.py
@@ -1,6 +1,6 @@
 import logging
 
-from tornado.web import RequestHandler
+from tornado.web import RequestHandler, StaticFileHandler
 
 from amgut.util import AG_DATA_ACCESS
 from amgut import text_locale
@@ -49,3 +49,10 @@ class DBErrorHandler(BaseHandler):
             raise ValueError('DB Error not found: %s' % err)
         self.render("db_error.html", skid=self.current_user,
                     message=errors[err])
+
+class BaseStaticFileHandler(StaticFileHandler, BaseHandler):
+    def write_error(self, status_code, **kwargs):
+        if self.current_user:
+            self.render("404.html", skid=self.current_user)
+        else:
+            self.render("no_auth_404.html", loginerror="")

--- a/amgut/webserver.py
+++ b/amgut/webserver.py
@@ -5,11 +5,11 @@ from datetime import datetime
 
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
-from tornado.web import Application, StaticFileHandler
+from tornado.web import Application
 from tornado.options import define, options, parse_command_line
 
 from amgut.handlers.base_handlers import (
-    MainHandler, NoPageHandler, DBErrorHandler)
+    MainHandler, NoPageHandler, DBErrorHandler, BaseStaticFileHandler)
 from amgut import AMGUT_CONFIG
 
 from amgut.handlers.auth_handlers import (
@@ -53,9 +53,9 @@ DEBUG = True
 class QiimeWebApplication(Application):
     def __init__(self):
         handlers = [
-            (r"/results/(.*)", StaticFileHandler,
+            (r"/results/(.*)", BaseStaticFileHandler,
              {"path": AMGUT_CONFIG.base_data_dir}),
-            (r"/static/(.*)", StaticFileHandler, {"path": STATIC_PATH}),
+            (r"/static/(.*)", BaseStaticFileHandler, {"path": STATIC_PATH}),
             (r"/", MainHandler),
             (r"/db_error/", DBErrorHandler),
             (r"/auth/login/", AuthLoginHandler),


### PR DESCRIPTION
Non-existant static files are sent to our default 404 page.

Fixes #184.
