### PR TITLE
ENH: Align map legends to the right

### DIFF
--- a/amgut/templates/map.html
+++ b/amgut/templates/map.html
@@ -13,7 +13,7 @@
     <div id="map_canvas" style="width:100%; height:100%; opacity:0.8;"></div>
 </div>
 
-<div style="position:absolute; bottom: 30px; left:50px; opacity:0.9; width:260px;">
+<div style="position:absolute; bottom: 30px; right:0px; opacity:0.9; width:260px;">
     <div class="left menuheader" style="margin-top:10px;">
         <p>{% raw tl['MAP_TITLE'] %}</p>
     </div>


### PR DESCRIPTION
These were aligned to the left but I have changed that such that the 
overlapping doesn't happen with the KitID and password text boxes.

Fixes #266
