### PR TITLE
MAINT: Remove spaces from log files prefix

### DIFF
--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -16,6 +16,7 @@ HELP_EMAIL = "info@americangut.org"
 _SITEBASE = ''
 
 media_locale = {
+    'LOCALE': AMGUT_CONFIG.locale,
     'SITEBASE': _SITEBASE,
     'LOGO': _SITEBASE + '/static/img/ag_logo.jpg',
     'ANALYTICS_ID': 'UA-55353353-1',

--- a/amgut/webserver.py
+++ b/amgut/webserver.py
@@ -8,6 +8,8 @@ from tornado.ioloop import IOLoop
 from tornado.web import Application
 from tornado.options import define, options, parse_command_line
 
+from amgut import media_locale
+
 from amgut.handlers.base_handlers import (
     MainHandler, NoPageHandler, DBErrorHandler, BaseStaticFileHandler)
 from amgut import AMGUT_CONFIG
@@ -99,8 +101,9 @@ class QiimeWebApplication(Application):
 
 def main():
     # replace spaces for underscores to autocomplete easily in a shell
-    prefix = ("AMGUT_%d_%s.log" % (options.port,
-                                   str(datetime.now()))).replace(' ', '_')
+    # format looks like american_gut_8888_2014-10-06_15:30:20.256035.log
+    prefix = ("%s_%d_%s.log" % (media_locale['LOCALE'], options.port,
+                                str(datetime.now()))).replace(' ', '_')
     options.log_file_prefix = prefix
     options.logging = 'warning'
     parse_command_line()


### PR DESCRIPTION
Having them in place make autocompletion/usage in a shell session annoying.
