### PR TITLE
Add more informative error for tracing purposes

### DIFF
--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -467,8 +467,16 @@ class AGDataAccess(object):
             # Get survey id
             sql = ("SELECT survey_id FROM ag_login_surveys WHERE ag_login_id = "
                    "%s AND participant_name = %s")
+
             survey_id = conn_handler.execute_fetchone(
-                sql, (ag_login_id, participant_name))[0]
+                sql, (ag_login_id, participant_name))
+            if survey_id:
+                # remove the list encapulation
+                survey_id = survey_id[0]
+            else:
+                raise RuntimeError("No survey ID for ag_login_id %s and "
+                                   "participant name %s" % (ag_login_id,
+                                                            participant_name))
         else:
             # otherwise, it is an environmental sample
             survey_id = None


### PR DESCRIPTION
This adds a more informative error when the survey ID can't be found. Hopefully this will help in tracking down what is going on in #344 and other survey_id related issues.