### PR TITLE
Change to redirect to sitebase after registration

### DIFF
--- a/amgut/handlers/auth_handlers.py
+++ b/amgut/handlers/auth_handlers.py
@@ -42,7 +42,7 @@ class AuthRegisterHandoutHandler(BaseHandler):
             ag_login_id, skid, kitinfo['password'],
             kitinfo['swabs_per_kit'], kitinfo['verification_code'],
             printresults)
-        if success == -1:
+        if success != 1:
             self.redirect(media_locale['SITEBASE'] + '/db_error/?err=regkit')
             return
 
@@ -53,7 +53,7 @@ class AuthRegisterHandoutHandler(BaseHandler):
         for row in results:
             barcode = row[0]
             success = ag_data.addAGBarcode(ag_kit_id, barcode)
-            if success == -1:
+            if success != 1:
                 self.redirect((media_locale['SITEBASE'] +
                                '/db_error/?err=regbarcode'))
                 return
@@ -76,7 +76,8 @@ class AuthRegisterHandoutHandler(BaseHandler):
 
             self.render('help_request.html', skid=skid, result=result)
 
-        self.redirect(media_locale['SITEBASE'] + '/authed/portal/')
+        # added person but not logged in so just go back to sitebase
+        self.redirect(media_locale['SITEBASE'])
 
 
 class AuthLoginHandler(BaseHandler):


### PR DESCRIPTION
We are seeing a user error pop up every once and a while and this may be why. Technically never log the user in during registration, so can't redirect to the authed portal. Instead, this changes it to redirect to the standard portal.