### PR TITLE
Fixes for authentication redirects and Open Humans integration

### DIFF
--- a/amgut/handlers/base_handlers.py
+++ b/amgut/handlers/base_handlers.py
@@ -2,10 +2,10 @@ import logging
 
 from tornado.web import RequestHandler, StaticFileHandler
 
+from amgut import media_locale, text_locale
 from amgut.connections import ag_data
 from amgut.lib.config_manager import AMGUT_CONFIG
 from amgut.lib.mail import send_email
-from amgut import text_locale
 
 
 class BaseHandler(RequestHandler):
@@ -41,6 +41,27 @@ class BaseHandler(RequestHandler):
 
         send_email(formatted_email, "SERVER ERROR!",
                    recipient=AMGUT_CONFIG.error_email)
+
+    def redirect(self, url, permanent=False, status=None):
+        """
+        Account for the SITEBASE when redirecting to relative URLs.
+
+        This was easier than monkey-patching Request.full_url() or
+        re-implementing the authenticated decorator, which are the
+        alternatives.
+
+        If the SITEBASE is /AmericanGut, for example,
+        self.redirect('/authed/portal/') will redirect to
+        '/AmericanGut/authed/portal/'.
+        """
+        if (url.startswith('/') and
+                not url.lower().startswith(media_locale['SITEBASE'].lower())):
+            old_url = url
+            url = media_locale['SITEBASE'] + old_url
+
+            logging.info('redirecting {} to {}'.format(old_url, url))
+
+        super(BaseHandler, self).redirect(url, permanent, status)
 
     def head(self):
         """Satisfy servers that this url exists"""

--- a/amgut/handlers/open_humans.py
+++ b/amgut/handlers/open_humans.py
@@ -75,7 +75,7 @@ class OpenHumansLoginHandler(BaseHandler, OpenHumansMixin):
     _API_URL = urljoin(AMGUT_CONFIG.open_humans_base_url, '/api')
 
     _OAUTH_REDIRECT_URL = urljoin(AMGUT_CONFIG.base_url,
-                                  '/authed/connect/open-humans/')
+                                  'authed/connect/open-humans/')
 
     _OAUTH_AUTHORIZE_URL = urljoin(AMGUT_CONFIG.open_humans_base_url,
                                    '/oauth2/authorize/')

--- a/amgut/templates/open-humans.html
+++ b/amgut/templates/open-humans.html
@@ -70,7 +70,7 @@
     <p>Interested in exporting your data to an Open Humans account? Click the
       button below to begin the process.</p>
 
-    <a href="/authed/connect/open-humans/" title="Connect to Open Humans">
+    <a href="{% raw media_locale['SITEBASE'] %}/authed/connect/open-humans/" title="Connect to Open Humans">
       <img
         src="{% raw media_locale['SITEBASE'] %}/static/img/open-humans-export-half.png">
     </a>

--- a/amgut/webserver.py
+++ b/amgut/webserver.py
@@ -106,7 +106,7 @@ class QiimeWebApplication(Application):
             "debug": DEBUG,
             "cookie_secret": COOKIE_SECRET,
             # Currently the only login form is on the homepage
-            "login_url": "/",
+            "login_url": media_locale['SITEBASE'] + '/',
         }
         super(QiimeWebApplication, self).__init__(handlers, **settings)
 


### PR DESCRIPTION
In addition to this code the setting `BASE_URL` also needs to be set to:

```
https://microbio.me/AmericanGut/
```

if it's not already. :)

I've tested this locally by proxying HTTP requests to `http://localhost/AmericanGut/*` to a running instance of `american-gut-web` with its `SITEBASE` set to `/AmericanGut`.