### PR TITLE
Fix sample logging image links

### DIFF
--- a/amgut/templates/add_sample_overview.html
+++ b/amgut/templates/add_sample_overview.html
@@ -8,18 +8,18 @@
 
 {% for hp in human_participants %}
     <a href="{% raw media_locale['SITEBASE'] %}/authed/add_sample_human/?participant_name={{hp}}">
-        <div class="source_icon"><div style="background-image:url({% raw media_locale['SITEBASE'] %} + '/static/img/human_transp.png');  background-repeat:no-repeat; background-position:0% 0%;"><h2>{{hp}}</h2></div></div>
+        <div class="source_icon"><div style="background-image:url('{% raw media_locale['SITEBASE'] %}/static/img/human_transp.png');  background-repeat:no-repeat; background-position:0% 0%;"><h2>{{hp}}</h2></div></div>
     </a>
 
 {% end %}
 
 {% for ap in animal_participants %}
     <a href="{% raw media_locale['SITEBASE'] %}/authed/add_sample_animal/?participant_name={{ap}}">
-        <div class="source_icon"><div style="background-image:url({% raw media_locale['SITEBASE'] %} + '/static/img/animal_transp.png'); background-repeat:no-repeat; background-position:0% 0%;"><h2>{{ap}}</h2></div></div>
+        <div class="source_icon"><div style="background-image:url('{% raw media_locale['SITEBASE'] %}/static/img/animal_transp.png'); background-repeat:no-repeat; background-position:0% 0%;"><h2>{{ap}}</h2></div></div>
     </a>
 {% end %}
     <a href="{% raw media_locale['SITEBASE'] %}/authed/add_sample_general/">
-        <div class="source_icon"><div style="background-image:url({% raw media_locale['SITEBASE'] %} + '/static/img/environmental_transp.png');  background-repeat:no-repeat; background-position:0% 0%;"><h2>{% raw tl['ENVIRONMENTAL'] %}</h2></div></div></a>
+        <div class="source_icon"><div style="background-image:url('{% raw media_locale['SITEBASE'] %}/static/img/environmental_transp.png');  background-repeat:no-repeat; background-position:0% 0%;"><h2>{% raw tl['ENVIRONMENTAL'] %}</h2></div></div></a>
     </a>
 </div>
 <br />


### PR DESCRIPTION
The images used for showing human vs pet vs environmental were broken. This fixes the URL used so they show again.

![screen shot 2015-04-17 at 9 38 17 am](https://cloud.githubusercontent.com/assets/3079066/7206377/9d32fe30-e4e5-11e4-9499-475cce31ffec.png)
