### PR TITLE
Email consent

### DIFF
--- a/amgut/handlers/human_survey_completed.py
+++ b/amgut/handlers/human_survey_completed.py
@@ -1,4 +1,4 @@
-from logging import Logger
+import logging
 
 from tornado.web import authenticated
 
@@ -87,10 +87,10 @@ class HumanSurveyCompletedHandler(BaseHandler):
                 send_email(message, 'American Gut - Signed Consent Form(s)',
                            recipient=consent_info['participant_email'])
             except:
-                Logger.exception('Error sending signed consent form for '
-                                 'survey ID: %s to email: %s' %
-                                 (human_survey_id,
-                                  consent_info['participant_email']))
+                logging.exception('Error sending signed consent form for '
+                                  'survey ID: %s to email: %s' %
+                                  (human_survey_id,
+                                   consent_info['participant_email']))
 
     @authenticated
     def post(self):

--- a/amgut/handlers/human_survey_completed.py
+++ b/amgut/handlers/human_survey_completed.py
@@ -1,8 +1,68 @@
+from logging import Logger
+
 from tornado.web import authenticated
 
 from amgut.lib.util import external_surveys
 from amgut.handlers.base_handlers import BaseHandler
-from amgut import media_locale
+from amgut import media_locale, text_locale
+from amgut.lib.mail import send_email
+from amgut.connections import ag_data
+
+
+def build_consent_form(consent_info):
+    tl = text_locale['new_participant.html']
+    # email out the consent form
+    if consent_info['age_range'] == '0-6':
+        message = ("%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
+                   "<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>") %\
+            (tl['CONSENT_YOUR_CHILD'],
+             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
+             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
+             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
+             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
+             tl['PARTICIPANT_DECEASED_PARENTS'],
+             consent_info['deceased_parent'],
+             tl['DATE_SIGNED'], consent_info['date_signed'])
+
+    elif consent_info['age_range'] == '7-12':
+        message = ("%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
+                   "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
+                   "<p>%s: %s</p>") %\
+            (tl['assent_7_12'],
+             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
+             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
+             tl['OBTAINER_NAME'], consent_info['assent_obtainer'],
+             tl['CONSENT_YOUR_CHILD'],
+             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
+             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
+             tl['PARTICIPANT_DECEASED_PARENTS'],
+             consent_info['deceased_parent'],
+             tl['DATE_SIGNED'], consent_info['date_signed'])
+
+    elif consent_info['age_range'] == '13-17':
+        message = ("%s<p>%s: %s</p><p>%s: %s</p>"
+                   "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
+                   "<p>%s: %s</p>") %\
+            (tl['assent_13_17'],
+             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
+             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
+             tl['CONSENT_YOUR_CHILD'],
+             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
+             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
+             tl['PARTICIPANT_DECEASED_PARENTS'],
+             consent_info['deceased_parent'],
+             tl['DATE_SIGNED'], consent_info['date_signed'])
+    elif consent_info['age_range'] == '18-plus':
+        message = "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>" %\
+            (tl['CONSENT_18'],
+             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
+             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
+             tl['DATE_SIGNED'], consent_info['date_signed'])
+
+    else:
+        # old consent so no idea of age range and text, only juv/non-juv
+        raise NotImplementedError("Old consent, no text available")
+    return message
 
 
 class HumanSurveyCompletedHandler(BaseHandler):
@@ -19,6 +79,15 @@ class HumanSurveyCompletedHandler(BaseHandler):
 
             self.render('human_survey_completed.html', skid=self.current_user,
                         surveys=surveys)
+            consent_info = ag_data.getConsent(human_survey_id)
+            message = build_consent_form(consent_info)
+
+            try:
+                send_email(message, 'American Gut - Signed Consent Form(s)',
+                           recipient=consent_info['participant_email'])
+            except:
+                Logger.exception('Error sending signed consent form for '
+                                 'survey ID: %s' % human_survey_id)
 
     @authenticated
     def post(self):

--- a/amgut/handlers/human_survey_completed.py
+++ b/amgut/handlers/human_survey_completed.py
@@ -88,7 +88,9 @@ class HumanSurveyCompletedHandler(BaseHandler):
                            recipient=consent_info['participant_email'])
             except:
                 Logger.exception('Error sending signed consent form for '
-                                 'survey ID: %s' % human_survey_id)
+                                 'survey ID: %s to email: %s' %
+                                 (human_survey_id,
+                                  consent_info['participant_email']))
 
     @authenticated
     def post(self):

--- a/amgut/handlers/human_survey_completed.py
+++ b/amgut/handlers/human_survey_completed.py
@@ -22,13 +22,13 @@ def build_consent_form(consent_info):
              tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
              tl['PARTICIPANT_DECEASED_PARENTS'],
              consent_info['deceased_parent'],
-             tl['DATE_SIGNED'], consent_info['date_signed'])
+             tl['DATE_SIGNED'], str(consent_info['date_signed']))
 
     elif consent_info['age_range'] == '7-12':
         message = ("%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
                    "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
                    "<p>%s: %s</p>") %\
-            (tl['assent_7_12'],
+            (tl['ASSENT_7_12'],
              tl['PARTICIPANT_NAME'], consent_info['participant_name'],
              tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
              tl['OBTAINER_NAME'], consent_info['assent_obtainer'],
@@ -37,13 +37,13 @@ def build_consent_form(consent_info):
              tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
              tl['PARTICIPANT_DECEASED_PARENTS'],
              consent_info['deceased_parent'],
-             tl['DATE_SIGNED'], consent_info['date_signed'])
+             tl['DATE_SIGNED'], str(consent_info['date_signed']))
 
     elif consent_info['age_range'] == '13-17':
         message = ("%s<p>%s: %s</p><p>%s: %s</p>"
                    "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
                    "<p>%s: %s</p>") %\
-            (tl['assent_13_17'],
+            (tl['ASSENT_13_17'],
              tl['PARTICIPANT_NAME'], consent_info['participant_name'],
              tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
              tl['CONSENT_YOUR_CHILD'],
@@ -51,13 +51,14 @@ def build_consent_form(consent_info):
              tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
              tl['PARTICIPANT_DECEASED_PARENTS'],
              consent_info['deceased_parent'],
-             tl['DATE_SIGNED'], consent_info['date_signed'])
+             tl['DATE_SIGNED'], str(consent_info['date_signed']))
+
     elif consent_info['age_range'] == '18-plus':
         message = "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>" %\
             (tl['CONSENT_18'],
              tl['PARTICIPANT_NAME'], consent_info['participant_name'],
              tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
-             tl['DATE_SIGNED'], consent_info['date_signed'])
+             tl['DATE_SIGNED'], str(consent_info['date_signed']))
 
     else:
         # old consent so no idea of age range and text, only juv/non-juv

--- a/amgut/handlers/human_survey_completed.py
+++ b/amgut/handlers/human_survey_completed.py
@@ -85,7 +85,8 @@ class HumanSurveyCompletedHandler(BaseHandler):
 
             try:
                 send_email(message, 'American Gut - Signed Consent Form(s)',
-                           recipient=consent_info['participant_email'])
+                           recipient=consent_info['participant_email'],
+                           sender='donotreply@americangut.com', html=True)
             except:
                 logging.exception('Error sending signed consent form for '
                                   'survey ID: %s to email: %s' %

--- a/amgut/handlers/new_participant.py
+++ b/amgut/handlers/new_participant.py
@@ -41,7 +41,7 @@ class NewParticipantHandler(BaseHandler):
         parent_1_name = self.get_argument("parent_1_name", None)
         parent_2_name = self.get_argument("parent_2_name", None)
         obtainer_name = self.get_argument("obtainer_name", None)
-        deceased_parent = self.get_argument("deceased_parent", None)
+        deceased_parent = self.get_argument("deceased_parent", 'No')
 
         ag_login_id = ag_data.get_user_for_kit(self.current_user)
 

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -506,10 +506,13 @@ class AGDataAccess(object):
                                   agc.is_juvenile,
                                   agc.deceased_parent,
                                   agc.ag_login_id,
+                                  agc.date_signed,
+                                  agc.assent_obtainer,
+                                  agc.age_range,
                                   agl.survey_id
                            FROM ag_consent agc JOIN
-                                ag_login_surveys agl ON agc.ag_login_id=agl.ag_login_id AND
-                                                        agc.participant_name=agl.participant_name
+                                ag_login_surveys agl
+                                USING (ag_login_id, participant_name)
                            WHERE agl.survey_id=%s""", [survey_id])
             colnames = [x[0] for x in cur.description]
             result = cur.fetchone()

--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -543,7 +543,8 @@ The following tests are available:</p>
     'PARTICIPANT_EMAIL': 'Email of participant',
     'PARTICIPANT_PARENT_1': 'Parent/Guardian name',
     'PARTICIPANT_PARENT_2': 'Parent/Guardian name of second parent',
-    'PARTICIPANT_DECEASED_PARENTS': 'One parent/guardian is deceased or unable to consent.'
+    'PARTICIPANT_DECEASED_PARENTS': 'One parent/guardian is deceased or unable to consent.',
+    'DATE_SIGNED': 'Date Signed'
 }
 
 _MAP = {

--- a/amgut/lib/locale_data/british_gut.py
+++ b/amgut/lib/locale_data/british_gut.py
@@ -360,7 +360,8 @@ The following tests are available:</p>
     'PARTICIPANT_EMAIL': 'Email of participant',
     'PARTICIPANT_PARENT_1': 'Parent/Guardian name',
     'PARTICIPANT_PARENT_2': 'Parent/Guardian name of second parent',
-    'PARTICIPANT_DECEASED_PARENTS': 'One parent/guardian is deceased or unable to consent.'
+    'PARTICIPANT_DECEASED_PARENTS': 'One parent/guardian is deceased or unable to consent.',
+    'DATE_SIGNED': 'Date Signed'
 }
 
 _FAQ = {

--- a/amgut/lib/mail.py
+++ b/amgut/lib/mail.py
@@ -2,18 +2,21 @@ import errno
 import smtplib
 import socket
 
-from email.mime.text import MIMEText
+from email.mime.text import MIMEText, MIME
 
 from amgut import media_locale
 from amgut.lib.config_manager import AMGUT_CONFIG
 
 
 def send_email(message, subject, recipient='americangut@gmail.com',
-               sender=media_locale['HELP_EMAIL']):
+               sender=media_locale['HELP_EMAIL'], html=False):
     """Send an email from your local host"""
 
-    # Create a text/plain message
-    msg = MIMEText(message)
+    if html:
+        mail_type = "html"
+    else:
+        mail_type = "plain"
+    msg = MIMEText(message, mail_type)
 
     # me == the sender's email address
     # you == the recipient's email address

--- a/amgut/lib/mail.py
+++ b/amgut/lib/mail.py
@@ -2,7 +2,7 @@ import errno
 import smtplib
 import socket
 
-from email.mime.text import MIMEText, MIME
+from email.mime.text import MIMEText
 
 from amgut import media_locale
 from amgut.lib.config_manager import AMGUT_CONFIG

--- a/amgut/lib/mail.py
+++ b/amgut/lib/mail.py
@@ -12,11 +12,7 @@ def send_email(message, subject, recipient='americangut@gmail.com',
                sender=media_locale['HELP_EMAIL'], html=False):
     """Send an email from your local host"""
 
-    if html:
-        mail_type = "html"
-    else:
-        mail_type = "plain"
-    msg = MIMEText(message, mail_type)
+    msg = MIMEText(message, "html" if html else "plain")
 
     # me == the sender's email address
     # you == the recipient's email address

--- a/amgut/templates/new_participant.html
+++ b/amgut/templates/new_participant.html
@@ -64,7 +64,7 @@
     <div class="" id="consent">
         <hr>
         <form method="post" id="7-12-form" name="consent_info" action="{% raw media_locale['SITEBASE'] %}/authed/new_participant/">
-           <input type="hidden" name="age_range" value="7-12">
+        <input type="hidden" name="age_range" value="7-12">
            <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required="required"> {% raw tl['TEXT_I_HAVE_READ_SIMPLIFIED'] %}</p>
     </div>
     <p><table>
@@ -128,7 +128,7 @@
         <hr>
         <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
         <form method="post" id="18-form" name="consent_info" action="{% raw media_locale['SITEBASE'] %}/authed/new_participant/">
-        <input type="hidden" name="age_range" value="18">
+        <input type="hidden" name="age_range" value="18-plus">
            <p><input value="Yes" type="checkbox" name="consent" id="consent" required="required"> {% raw tl['TEXT_I_HAVE_READ_1'] %}</p>
     </div>
     <p><table>


### PR DESCRIPTION
This is needed before final deploy. Sends the consent form as an email to the person after the survey is completed and consent is entered on the database.