### PR TITLE
Fix multi-email issue

### DIFF
--- a/amgut/handlers/human_survey.py
+++ b/amgut/handlers/human_survey.py
@@ -1,15 +1,74 @@
 from json import dumps, loads
 from collections import defaultdict
+import logging
 
 from wtforms import Form
 from tornado.web import authenticated
 from tornado.escape import url_escape
 
-from amgut import media_locale
+from amgut import media_locale, text_locale
 from amgut.connections import ag_data, redis
 from amgut.handlers.base_handlers import BaseHandler
 from amgut.lib.util import store_survey
 from amgut.lib.survey_supp import primary_human_survey
+from amgut.lib.mail import send_email
+
+
+def build_consent_form(consent_info):
+    tl = text_locale['new_participant.html']
+    # email out the consent form
+    if consent_info['age_range'] == '0-6':
+        message = ("%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
+                   "<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>") %\
+            (tl['CONSENT_YOUR_CHILD'],
+             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
+             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
+             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
+             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
+             tl['PARTICIPANT_DECEASED_PARENTS'],
+             consent_info['deceased_parent'],
+             tl['DATE_SIGNED'], str(consent_info['date_signed']))
+
+    elif consent_info['age_range'] == '7-12':
+        message = ("%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
+                   "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
+                   "<p>%s: %s</p>") %\
+            (tl['ASSENT_7_12'],
+             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
+             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
+             tl['OBTAINER_NAME'], consent_info['assent_obtainer'],
+             tl['CONSENT_YOUR_CHILD'],
+             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
+             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
+             tl['PARTICIPANT_DECEASED_PARENTS'],
+             consent_info['deceased_parent'],
+             tl['DATE_SIGNED'], str(consent_info['date_signed']))
+
+    elif consent_info['age_range'] == '13-17':
+        message = ("%s<p>%s: %s</p><p>%s: %s</p>"
+                   "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
+                   "<p>%s: %s</p>") %\
+            (tl['ASSENT_13_17'],
+             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
+             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
+             tl['CONSENT_YOUR_CHILD'],
+             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
+             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
+             tl['PARTICIPANT_DECEASED_PARENTS'],
+             consent_info['deceased_parent'],
+             tl['DATE_SIGNED'], str(consent_info['date_signed']))
+
+    elif consent_info['age_range'] == '18-plus':
+        message = "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>" %\
+            (tl['CONSENT_18'],
+             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
+             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
+             tl['DATE_SIGNED'], str(consent_info['date_signed']))
+
+    else:
+        # old consent so no idea of age range and text, only juv/non-juv
+        raise NotImplementedError("Old consent, no text available")
+    return message
 
 
 def make_human_survey_class(group):
@@ -102,6 +161,21 @@ class HumanSurveyHandler(BaseHandler):
             self.clear_cookie('human_survey_id')
             self.set_secure_cookie('completed_survey_id', human_survey_id)
             store_survey(primary_human_survey, human_survey_id)
+            existing = redis.hget(human_survey_id, 'existing')
+            if existing is None:
+                # Send consent info email since new participant
+                consent_info = ag_data.getConsent(human_survey_id)
+                try:
+                    message = build_consent_form(consent_info)
+                    send_email(message, 'American Gut-Signed Consent Form(s)',
+                               recipient=consent_info['participant_email'],
+                               sender='donotreply@americangut.com', html=True)
+                except:
+                    logging.exception('Error sending signed consent form for '
+                                      'survey ID: %s to email: %s' %
+                                      (human_survey_id,
+                                       consent_info['participant_email']))
+
             self.redirect(media_locale['SITEBASE'] +
                           '/authed/human_survey_completed/')
 

--- a/amgut/handlers/human_survey.py
+++ b/amgut/handlers/human_survey.py
@@ -16,7 +16,7 @@ from amgut.lib.mail import send_email
 
 def build_consent_form(consent_info):
     tl = text_locale['new_participant.html']
-    # email out the consent form
+    # build out the consent form
     if consent_info['age_range'] == '0-6':
         message = ("%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
                    "<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>") %\

--- a/amgut/handlers/human_survey_completed.py
+++ b/amgut/handlers/human_survey_completed.py
@@ -1,69 +1,8 @@
-import logging
-
 from tornado.web import authenticated
 
 from amgut.lib.util import external_surveys
 from amgut.handlers.base_handlers import BaseHandler
-from amgut import media_locale, text_locale
-from amgut.lib.mail import send_email
-from amgut.connections import ag_data
-
-
-def build_consent_form(consent_info):
-    tl = text_locale['new_participant.html']
-    # email out the consent form
-    if consent_info['age_range'] == '0-6':
-        message = ("%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
-                   "<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>") %\
-            (tl['CONSENT_YOUR_CHILD'],
-             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
-             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
-             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
-             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
-             tl['PARTICIPANT_DECEASED_PARENTS'],
-             consent_info['deceased_parent'],
-             tl['DATE_SIGNED'], str(consent_info['date_signed']))
-
-    elif consent_info['age_range'] == '7-12':
-        message = ("%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
-                   "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
-                   "<p>%s: %s</p>") %\
-            (tl['ASSENT_7_12'],
-             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
-             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
-             tl['OBTAINER_NAME'], consent_info['assent_obtainer'],
-             tl['CONSENT_YOUR_CHILD'],
-             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
-             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
-             tl['PARTICIPANT_DECEASED_PARENTS'],
-             consent_info['deceased_parent'],
-             tl['DATE_SIGNED'], str(consent_info['date_signed']))
-
-    elif consent_info['age_range'] == '13-17':
-        message = ("%s<p>%s: %s</p><p>%s: %s</p>"
-                   "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>"
-                   "<p>%s: %s</p>") %\
-            (tl['ASSENT_13_17'],
-             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
-             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
-             tl['CONSENT_YOUR_CHILD'],
-             tl['PARTICIPANT_PARENT_1'], consent_info['parent_1_name'],
-             tl['PARTICIPANT_PARENT_2'], consent_info['parent_2_name'],
-             tl['PARTICIPANT_DECEASED_PARENTS'],
-             consent_info['deceased_parent'],
-             tl['DATE_SIGNED'], str(consent_info['date_signed']))
-
-    elif consent_info['age_range'] == '18-plus':
-        message = "%s<p>%s: %s</p><p>%s: %s</p><p>%s: %s</p>" %\
-            (tl['CONSENT_18'],
-             tl['PARTICIPANT_NAME'], consent_info['participant_name'],
-             tl['PARTICIPANT_EMAIL'], consent_info['participant_email'],
-             tl['DATE_SIGNED'], str(consent_info['date_signed']))
-
-    else:
-        # old consent so no idea of age range and text, only juv/non-juv
-        raise NotImplementedError("Old consent, no text available")
-    return message
+from amgut import media_locale
 
 
 class HumanSurveyCompletedHandler(BaseHandler):
@@ -80,18 +19,6 @@ class HumanSurveyCompletedHandler(BaseHandler):
 
             self.render('human_survey_completed.html', skid=self.current_user,
                         surveys=surveys)
-            consent_info = ag_data.getConsent(human_survey_id)
-            message = build_consent_form(consent_info)
-
-            try:
-                send_email(message, 'American Gut - Signed Consent Form(s)',
-                           recipient=consent_info['participant_email'],
-                           sender='donotreply@americangut.com', html=True)
-            except:
-                logging.exception('Error sending signed consent form for '
-                                  'survey ID: %s to email: %s' %
-                                  (human_survey_id,
-                                   consent_info['participant_email']))
 
     @authenticated
     def post(self):


### PR DESCRIPTION
This makes it so you only get a consent form email on first pass at the survey when creating a new participant. It will no longer try and email you after editing a survey.