### PR TITLE
Add source info to logging

### DIFF
--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -244,13 +244,15 @@ _PARTICIPANT_OVERVIEW = {
     'OVERVIEW_FOR_PARTICPANT': 'Overview for participant'
 }
 
-_ADD_SAMPLE_OVERIVIEW = {
+_ADD_SAMPLE_OVERVIEW = {
     'ADD_SAMPLE_TITLE': 'Choose your sample source ',
     'ADD_SAMPLE_TITLE_HELP': 'The sample source is the person, animal or environment that the sample you are currently logging came from. If you took the sample from yourself, you should select yourself as the sample source.',
     'ENVIRONMENTAL': 'Environmental',
     'ADD_SAMPLE_1': 'If you don\'t see the sample source you want here, you need to add it. You can do this in ',
     'ADD_SAMPLE_2': 'Step 2',
     'ADD_SAMPLE_3': ' on the main page when you log in.',
+    'HUMAN_SOURCE': 'Human Source',
+    'ANIMAL_SOURCE': 'Animal Source'
 }
 
 _SAMPLE_OVERVIEW = {
@@ -965,7 +967,7 @@ text_locale = {
     'help_request.html': _HELP_REQUEST,
     'new_participant.html': _NEW_PARTICIPANT,
     'international.html': _INTERNATIONAL,
-    'add_sample_overview.html': _ADD_SAMPLE_OVERIVIEW,
+    'add_sample_overview.html': _ADD_SAMPLE_OVERVIEW,
     'participant_overview.html': _PARTICIPANT_OVERVIEW,
     'sample_overview.html': _SAMPLE_OVERVIEW,
     'taxa_summary.html': _TAXA_SUMMARY,

--- a/amgut/lib/locale_data/british_gut.py
+++ b/amgut/lib/locale_data/british_gut.py
@@ -607,13 +607,15 @@ _ANIMAL_SURVEY = {
     'SUPPLEMENTAL_COMMENTS': 'Please write anything else about this animal that you think might affect its microorganisms.'
 }
 
-_ADD_SAMPLE_OVERIVIEW = {
+_ADD_SAMPLE_OVERVIEW = {
     'ENVIRONMENTAL': 'Environmental',
     'ADD_SAMPLE_3': 'on the main page when you log in.',
     'ADD_SAMPLE_2': 'Step 2',
     'ADD_SAMPLE_1': 'If you don\'t see the sample source you want here, you need to add it. You can do this in ',
     'ADD_SAMPLE_TITLE': 'Choose your sample source ',
     'ADD_SAMPLE_TITLE_HELP': 'The sample source is the person, animal or environment that the sample you are currently logging came from. If you took the sample from yourself, you should select yourself as the sample source.',
+    'HUMAN_SOURCE': 'Human Source',
+    'ANIMAL_SOURCE': 'Animal Source'
     }
 
 _SAMPLE_OVERVIEW = {
@@ -941,7 +943,7 @@ text_locale = {
     'help_request.html': _HELP_REQUEST,
     'new_participant.html': _NEW_PARTICIPANT,
     'international.html': _INTERNATIONAL,
-    'add_sample_overview.html': _ADD_SAMPLE_OVERIVIEW,
+    'add_sample_overview.html': _ADD_SAMPLE_OVERVIEW,
     'participant_overview.html': _PARTICIPANT_OVERVIEW,
     'sample_overview.html': _SAMPLE_OVERVIEW,
     'taxa_summary.html': _TAXA_SUMMARY,

--- a/amgut/templates/add_sample_overview.html
+++ b/amgut/templates/add_sample_overview.html
@@ -8,14 +8,14 @@
 
 {% for hp in human_participants %}
     <a href="{% raw media_locale['SITEBASE'] %}/authed/add_sample_human/?participant_name={{hp}}">
-        <div class="source_icon"><div style="background-image:url('{% raw media_locale['SITEBASE'] %}/static/img/human_transp.png');  background-repeat:no-repeat; background-position:0% 0%;"><h2>{{hp}}</h2></div></div>
+        <div class="source_icon"><div style="background-image:url('{% raw media_locale['SITEBASE'] %}/static/img/human_transp.png');  background-repeat:no-repeat; background-position:0% 0%;"><h2>{{hp}} - {% raw tl['HUMAN_SOURCE'] %}</h2></div></div>
     </a>
 
 {% end %}
 
 {% for ap in animal_participants %}
     <a href="{% raw media_locale['SITEBASE'] %}/authed/add_sample_animal/?participant_name={{ap}}">
-        <div class="source_icon"><div style="background-image:url('{% raw media_locale['SITEBASE'] %}/static/img/animal_transp.png'); background-repeat:no-repeat; background-position:0% 0%;"><h2>{{ap}}</h2></div></div>
+        <div class="source_icon"><div style="background-image:url('{% raw media_locale['SITEBASE'] %}/static/img/animal_transp.png'); background-repeat:no-repeat; background-position:0% 0%;"><h2>{{ap}} - {% raw tl['ANIMAL_SOURCE'] %}</h2></div></div>
     </a>
 {% end %}
     <a href="{% raw media_locale['SITEBASE'] %}/authed/add_sample_general/">


### PR DESCRIPTION
This adds a "[NAME] - Human Source" and "[NAME] - Animal Source" to the logging to stop people being confused and not realizing their name corresponds to a human sample.