### PR TITLE
Fix handouts table - NEEDS REVIEW

### DIFF
--- a/amgut/db/ag.dbs
+++ b/amgut/db/ag.dbs
@@ -54,6 +54,27 @@
 				<fk_column name="ag_login_id" pk="ag_login_id" />
 			</fk>
 		</table>
+		<table name="ag_handout_barcodes" >
+			<column name="kit_id" type="varchar" jt="12" mandatory="y" />
+			<column name="barcode" type="varchar" length="9" jt="12" mandatory="y" />
+			<column name="sample_barcode_file" type="varchar" length="13" jt="12" mandatory="y" />
+			<index name="idx_handout_barcode" unique="PRIMARY_KEY" >
+				<column name="kit_id" />
+				<column name="barcode" />
+			</index>
+			<index name="idx_handout_barcode_0" unique="NORMAL" >
+				<column name="barcode" />
+			</index>
+			<index name="idx_handout_barcode_1" unique="NORMAL" >
+				<column name="kit_id" />
+			</index>
+			<fk name="fk_handout_barcode" to_schema="ag" to_table="barcode" >
+				<fk_column name="barcode" pk="barcode" />
+			</fk>
+			<fk name="fk_handout_barcode_0" to_schema="ag" to_table="ag_handout_kits" delete_action="cascade" update_action="cascade" >
+				<fk_column name="kit_id" pk="kit_id" />
+			</fk>
+		</table>
 		<table name="ag_handout_kits" >
 			<column name="kit_id" type="varchar" length="9" jt="12" mandatory="y" />
 			<column name="password" type="varchar" length="11" jt="12" />
@@ -450,27 +471,6 @@
 			</fk>
 			<fk name="fk_human_survey_group_question_0" to_schema="ag" to_table="survey_question" >
 				<fk_column name="survey_question_id" pk="survey_question_id" />
-			</fk>
-		</table>
-		<table name="handout_barcode" >
-			<column name="kit_id" type="varchar" jt="12" mandatory="y" />
-			<column name="barcode" type="varchar" length="9" jt="12" mandatory="y" />
-			<column name="sample_barcode_file" type="varchar" length="13" jt="12" mandatory="y" />
-			<index name="idx_handout_barcode" unique="PRIMARY_KEY" >
-				<column name="kit_id" />
-				<column name="barcode" />
-			</index>
-			<index name="idx_handout_barcode_0" unique="NORMAL" >
-				<column name="barcode" />
-			</index>
-			<index name="idx_handout_barcode_1" unique="NORMAL" >
-				<column name="kit_id" />
-			</index>
-			<fk name="fk_handout_barcode" to_schema="ag" to_table="barcode" >
-				<fk_column name="barcode" pk="barcode" />
-			</fk>
-			<fk name="fk_handout_barcode_0" to_schema="ag" to_table="ag_handout_kits" delete_action="cascade" update_action="cascade" >
-				<fk_column name="kit_id" pk="kit_id" />
 			</fk>
 		</table>
 		<table name="iso_country_lookup" >
@@ -21374,8 +21374,8 @@ AS $function$xpath_exists$function$
 		<entity schema="ag" name="project" color="c6d9f7" x="405" y="855" />
 		<entity schema="ag" name="barcode_exceptions" color="c6c6f7" x="45" y="1065" />
 		<entity schema="ag" name="ag_map_markers" color="cef7c6" x="60" y="90" />
-		<entity schema="ag" name="handout_barcode" color="a8c4ef" x="255" y="420" />
 		<entity schema="ag" name="ag_handout_kits" color="ccccff" x="45" y="420" />
+		<entity schema="ag" name="ag_handout_barcodes" color="a8c4ef" x="255" y="420" />
 		<group name="ag_survey_multiples" color="faf6f0" >
 			<comment>Used by : 
    american_gut_consent</comment>
@@ -21429,7 +21429,7 @@ AS $function$xpath_exists$function$
 		</group>
 		<group name="Group_handout_kits" color="c4e0f9" >
 			<entity schema="ag" name="ag_handout_kits" />
-			<entity schema="ag" name="handout_barcode" />
+			<entity schema="ag" name="ag_handout_barcodes" />
 		</group>
 	</layout>
 </project>

--- a/amgut/db/ag.dbs
+++ b/amgut/db/ag.dbs
@@ -57,23 +57,17 @@
 		<table name="ag_handout_kits" >
 			<column name="kit_id" type="varchar" length="9" jt="12" mandatory="y" />
 			<column name="password" type="varchar" length="11" jt="12" />
-			<column name="barcode" type="varchar" length="9" jt="12" mandatory="y" />
 			<column name="verification_code" type="varchar" length="5" jt="12" />
-			<column name="sample_barcode_file" type="varchar" length="13" jt="12" />
 			<column name="swabs_per_kit" type="bigint" length="19" jt="-5" />
 			<column name="print_results" type="varchar" length="1" jt="12" >
 				<defo>&#039;n&#039;::character varying</defo>
 			</column>
+			<column name="created_on" type="timestamp" jt="93" mandatory="y" >
+				<defo>current_timestamp</defo>
+			</column>
 			<index name="pk_ag_handout_kits" unique="PRIMARY_KEY" >
 				<column name="kit_id" />
-				<column name="barcode" />
 			</index>
-			<index name="idx_ag_handout_kits" unique="UNIQUE" >
-				<column name="barcode" />
-			</index>
-			<fk name="fk_ag_handout_kits" to_schema="ag" to_table="barcode" >
-				<fk_column name="barcode" pk="barcode" />
-			</fk>
 		</table>
 		<table name="ag_human_survey" >
 			<column name="ag_login_id" type="uuid" length="2147483647" jt="1111" mandatory="y" />
@@ -456,6 +450,27 @@
 			</fk>
 			<fk name="fk_human_survey_group_question_0" to_schema="ag" to_table="survey_question" >
 				<fk_column name="survey_question_id" pk="survey_question_id" />
+			</fk>
+		</table>
+		<table name="handout_barcode" >
+			<column name="kit_id" type="varchar" jt="12" mandatory="y" />
+			<column name="barcode" type="varchar" length="9" jt="12" mandatory="y" />
+			<column name="sample_barcode_file" type="varchar" length="13" jt="12" mandatory="y" />
+			<index name="idx_handout_barcode" unique="PRIMARY_KEY" >
+				<column name="kit_id" />
+				<column name="barcode" />
+			</index>
+			<index name="idx_handout_barcode_0" unique="NORMAL" >
+				<column name="barcode" />
+			</index>
+			<index name="idx_handout_barcode_1" unique="NORMAL" >
+				<column name="kit_id" />
+			</index>
+			<fk name="fk_handout_barcode" to_schema="ag" to_table="barcode" >
+				<fk_column name="barcode" pk="barcode" />
+			</fk>
+			<fk name="fk_handout_barcode_0" to_schema="ag" to_table="ag_handout_kits" delete_action="cascade" update_action="cascade" >
+				<fk_column name="kit_id" pk="kit_id" />
 			</fk>
 		</table>
 		<table name="iso_country_lookup" >
@@ -21324,42 +21339,43 @@ AS $function$xpath_exists$function$
 	</schema>
 	<connector name="PostgreSQL" database="PostgreSQL" driver_class="org.postgresql.Driver" driver_jar="postgresql-9.2-1003.jdbc3.jar" host="webdev-kl4.colorado.edu" port="5432" instance="ag" user="americangut" schema_mapping="" />
 	<layout id="Layout2861625" name="public" joined_routing="y" show_relation_columns="y" >
-		<entity schema="ag" name="ag_map_markers" color="cef7c6" x="45" y="315" />
-		<entity schema="ag" name="ag_survey_answer" color="f7e2c6" x="720" y="690" />
-		<entity schema="ag" name="controlled_vocab_values" color="c6c6f7" x="930" y="45" />
-		<entity schema="ag" name="controlled_vocabs" color="c6c6f7" x="720" y="45" />
-		<entity schema="ag" name="ag_participant_exceptions" color="f7e2c6" x="1125" y="315" />
-		<entity schema="ag" name="ag_animal_survey" color="f7e2c6" x="930" y="285" />
-		<entity schema="ag" name="ag_survey_multiples" color="f7e2c6" x="945" y="750" />
-		<entity schema="ag" name="group_questions" color="ffcccc" x="345" y="1365" />
-		<entity schema="ag" name="survey_response_types" color="ffffff" x="1035" y="1740" />
-		<entity schema="ag" name="surveys" color="a8c4ef" x="90" y="1530" />
-		<entity schema="ag" name="survey_group" color="a8c4ef" x="90" y="1365" />
-		<entity schema="ag" name="ag_kit" color="f7e2c6" x="1155" y="690" />
-		<entity schema="ag" name="survey_answers_other" color="a8c4ef" x="1350" y="1140" />
-		<entity schema="ag" name="survey_question_triggers" color="a8c4ef" x="690" y="1425" />
-		<entity schema="ag" name="survey_response" color="a8c4ef" x="735" y="1635" />
-		<entity schema="ag" name="survey_question_response" color="ffcccc" x="735" y="1530" />
-		<entity schema="ag" name="ag_human_survey" color="c6d9f7" x="1710" y="420" />
-		<entity schema="ag" name="iso_country_lookup" color="ffffff" x="945" y="1620" />
-		<entity schema="ag" name="survey_question_response_type" color="ffcccc" x="735" y="1725" />
-		<entity schema="ag" name="ag_kit_barcodes" color="f7e2c6" x="780" y="885" />
-		<entity schema="ag" name="ag_login_surveys" color="ffcccc" x="1470" y="1020" />
-		<entity schema="ag" name="survey_answers" color="a8c4ef" x="1575" y="1200" />
-		<entity schema="ag" name="promoted_survey_ids" color="a8c4ef" x="1470" y="915" />
-		<entity schema="ag" name="survey_question" color="a8c4ef" x="465" y="1530" />
-		<entity schema="ag" name="ag_login" color="f7e2c6" x="750" y="405" />
-		<entity schema="ag" name="zipcodes" color="c6c6f7" x="1140" y="45" />
-		<entity schema="ag" name="ag_consent" color="c6d9f7" x="1485" y="675" />
-		<entity schema="ag" name="ag_survey_multiples_backup" color="cef7c6" x="195" y="330" />
-		<entity schema="ag" name="ag_import_stats_tmp" color="cef7c6" x="420" y="330" />
-		<entity schema="ag" name="barcode" color="c6c6f7" x="420" y="630" />
-		<entity schema="ag" name="project_barcode" color="c6d9f7" x="450" y="945" />
-		<entity schema="ag" name="plate" color="c6d9f7" x="435" y="1035" />
-		<entity schema="ag" name="plate_barcode" color="c6d9f7" x="450" y="1140" />
-		<entity schema="ag" name="project" color="c6d9f7" x="450" y="855" />
-		<entity schema="ag" name="barcode_exceptions" color="c6c6f7" x="90" y="1065" />
-		<entity schema="ag" name="ag_handout_kits" color="ccccff" x="90" y="870" />
+		<entity schema="ag" name="ag_survey_answer" color="f7e2c6" x="675" y="690" />
+		<entity schema="ag" name="controlled_vocab_values" color="c6c6f7" x="885" y="45" />
+		<entity schema="ag" name="controlled_vocabs" color="c6c6f7" x="675" y="45" />
+		<entity schema="ag" name="ag_participant_exceptions" color="f7e2c6" x="1080" y="315" />
+		<entity schema="ag" name="ag_animal_survey" color="f7e2c6" x="885" y="285" />
+		<entity schema="ag" name="ag_survey_multiples" color="f7e2c6" x="900" y="750" />
+		<entity schema="ag" name="group_questions" color="ffcccc" x="300" y="1365" />
+		<entity schema="ag" name="survey_response_types" color="ffffff" x="990" y="1740" />
+		<entity schema="ag" name="surveys" color="a8c4ef" x="45" y="1530" />
+		<entity schema="ag" name="survey_group" color="a8c4ef" x="45" y="1365" />
+		<entity schema="ag" name="ag_kit" color="f7e2c6" x="1110" y="690" />
+		<entity schema="ag" name="survey_answers_other" color="a8c4ef" x="1305" y="1140" />
+		<entity schema="ag" name="survey_question_triggers" color="a8c4ef" x="645" y="1425" />
+		<entity schema="ag" name="survey_response" color="a8c4ef" x="690" y="1635" />
+		<entity schema="ag" name="survey_question_response" color="ffcccc" x="690" y="1530" />
+		<entity schema="ag" name="ag_human_survey" color="c6d9f7" x="1665" y="420" />
+		<entity schema="ag" name="iso_country_lookup" color="ffffff" x="900" y="1620" />
+		<entity schema="ag" name="survey_question_response_type" color="ffcccc" x="690" y="1725" />
+		<entity schema="ag" name="ag_kit_barcodes" color="f7e2c6" x="735" y="885" />
+		<entity schema="ag" name="ag_login_surveys" color="ffcccc" x="1425" y="1020" />
+		<entity schema="ag" name="survey_answers" color="a8c4ef" x="1530" y="1200" />
+		<entity schema="ag" name="promoted_survey_ids" color="a8c4ef" x="1425" y="915" />
+		<entity schema="ag" name="survey_question" color="a8c4ef" x="420" y="1530" />
+		<entity schema="ag" name="ag_login" color="f7e2c6" x="705" y="405" />
+		<entity schema="ag" name="zipcodes" color="c6c6f7" x="1095" y="45" />
+		<entity schema="ag" name="ag_consent" color="c6d9f7" x="1440" y="675" />
+		<entity schema="ag" name="ag_survey_multiples_backup" color="cef7c6" x="195" y="90" />
+		<entity schema="ag" name="ag_import_stats_tmp" color="cef7c6" x="420" y="90" />
+		<entity schema="ag" name="barcode" color="c6c6f7" x="375" y="630" />
+		<entity schema="ag" name="project_barcode" color="c6d9f7" x="405" y="945" />
+		<entity schema="ag" name="plate" color="c6d9f7" x="390" y="1035" />
+		<entity schema="ag" name="plate_barcode" color="c6d9f7" x="405" y="1140" />
+		<entity schema="ag" name="project" color="c6d9f7" x="405" y="855" />
+		<entity schema="ag" name="barcode_exceptions" color="c6c6f7" x="45" y="1065" />
+		<entity schema="ag" name="ag_map_markers" color="cef7c6" x="60" y="90" />
+		<entity schema="ag" name="handout_barcode" color="a8c4ef" x="255" y="420" />
+		<entity schema="ag" name="ag_handout_kits" color="ccccff" x="45" y="420" />
 		<group name="ag_survey_multiples" color="faf6f0" >
 			<comment>Used by : 
    american_gut_consent</comment>
@@ -21409,8 +21425,11 @@ AS $function$xpath_exists$function$
 			<entity schema="ag" name="plate_barcode" />
 			<entity schema="ag" name="project_barcode" />
 			<entity schema="ag" name="project" />
-			<entity schema="ag" name="ag_handout_kits" />
 			<entity schema="ag" name="plate" />
+		</group>
+		<group name="Group_handout_kits" color="c4e0f9" >
+			<entity schema="ag" name="ag_handout_kits" />
+			<entity schema="ag" name="handout_barcode" />
 		</group>
 	</layout>
 </project>

--- a/amgut/db/ag.html
+++ b/amgut/db/ag.html
@@ -322,7 +322,7 @@
 	ag_kit_barcodes references ag_kit ( ag_kit_id )</title>
 </path>
 <text x='922' y='925' transform='rotate(0 922,925)' title='Foreign Key fk_ag_kit_barcodes
-	ag_kit_barcodes references ag_kit ( ag_kit_id )' style='fill:#a1a0a0;'>ag_kit_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 720 945 L 562,945 Q 555,945 555,937 L 555,667 Q 555,660 547,660 L 540,660' >
+	ag_kit_barcodes references ag_kit ( ag_kit_id )' style='fill:#a1a0a0;'>ag_kit_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 720 945 L 562,945 Q 555,945 555,937 L 555,667 Q 555,660 547,660 L 540,660' >
 	<title>Foreign Key fk_ag_kit_barcodes_0
 	ag_kit_barcodes references barcode ( barcode )</title>
 </path>
@@ -382,17 +382,17 @@
 	barcode_exceptions references barcode ( barcode )</title>
 </path>
 <text x='172' y='1090' transform='rotate(0 172,1090)' title='Foreign Key fk_barcode_exceptions
-	barcode_exceptions references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 405 465 L 547,465 Q 555,465 555,472 L 555,652 Q 555,660 547,660 L 540,660' >
+	barcode_exceptions references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 405 465 L 547,465 Q 555,465 555,472 L 555,652 Q 555,660 547,660 L 540,660' >
 	<title>Foreign Key fk_handout_barcode
-	handout_barcode references barcode ( barcode )</title>
+	ag_handout_barcodes references barcode ( barcode )</title>
 </path>
 <text x='412' y='460' transform='rotate(0 412,460)' title='Foreign Key fk_handout_barcode
-	handout_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 240 450 L 180,450' >
+	ag_handout_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 240 450 L 180,450' >
 	<title>Foreign Key fk_handout_barcode_0
-	handout_barcode references ag_handout_kits ( kit_id )</title>
+	ag_handout_barcodes references ag_handout_kits ( kit_id )</title>
 </path>
 <text x='213' y='445' transform='rotate(0 213,445)' title='Foreign Key fk_handout_barcode_0
-	handout_barcode references ag_handout_kits ( kit_id )' style='fill:#a1a0a0;'>kit_id</text><!-- ============= Table 'ag_survey_answer' ============= -->
+	ag_handout_barcodes references ag_handout_kits ( kit_id )' style='fill:#a1a0a0;'>kit_id</text><!-- ============= Table 'ag_survey_answer' ============= -->
 <rect class='table' x='675' y='683' width='150' height='120' rx='7' ry='7' />
 <path d='M 675.50 709.50 L 675.50 690.50 Q 675.50 683.50 682.50 683.50 L 817.50 683.50 Q 824.50 683.50 824.50 690.50 L 824.50 709.50 L675.50 709.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#ag_survey_answer'><text x='700' y='697' class='tableTitle'>ag_survey_answer</text><title>Table ag.ag_survey_answer</title></a>
@@ -949,7 +949,7 @@ Referred by ag_login_surveys ( ag_login_id, participant_name ) </title></a>
 <a xlink:href='#barcode'><text x='393' y='667'>barcode</text><title>barcode varchar not null</title></a>
 <a xlink:href='#barcode'><use id='ref' x='528' y='656' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( barcode ) 
 Referred by barcode_exceptions ( barcode ) 
-Referred by handout_barcode ( barcode ) 
+Referred by ag_handout_barcodes ( barcode ) 
 Referred by plate_barcode ( barcode ) 
 Referred by project_barcode ( barcode ) </title></a>
   <a xlink:href='#create_date_time'><text x='393' y='682'>create_date_time</text><title>create_date_time timestamp default &#040;&#039;now&#039;&#058;&#058;text&#041;&#058;&#058;timestamp without time zone</title></a>
@@ -1019,10 +1019,23 @@ Referred by project_barcode ( barcode ) </title></a>
   <a xlink:href='#marker_color'><text x='78' y='172'>marker_color</text><title>marker_color varchar&#040;10&#041;</title></a>
   <a xlink:href='#order_by'><text x='78' y='187'>order_by</text><title>order_by bigint</title></a>
 
-<!-- ============= Table 'handout_barcode' ============= -->
+<!-- ============= Table 'ag_handout_kits' ============= -->
+<rect class='table' x='45' y='413' width='135' height='135' rx='7' ry='7' />
+<path d='M 45.50 439.50 L 45.50 420.50 Q 45.50 413.50 52.50 413.50 L 172.50 413.50 Q 179.50 413.50 179.50 420.50 L 179.50 439.50 L45.50 439.50 ' style='fill:url(#tableHeaderGradient7); stroke:none;' />
+<a xlink:href='#ag_handout_kits'><text x='68' y='427' class='tableTitle'>ag_handout_kits</text><title>Table ag.ag_handout_kits</title></a>
+  <use id='nn' x='47' y='447' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='47' y='446' xlink:href='#pk'/><title>Primary Key  ( kit_id ) </title></a>
+<a xlink:href='#kit_id'><text x='63' y='457'>kit_id</text><title>kit_id varchar&#040;9&#041; not null</title></a>
+<a xlink:href='#kit_id'><use id='ref' x='168' y='446' xlink:href='#ref'/><title>Referred by ag_handout_barcodes ( kit_id ) </title></a>
+  <a xlink:href='#password'><text x='63' y='472'>password</text><title>password varchar&#040;11&#041;</title></a>
+  <a xlink:href='#verification_code'><text x='63' y='487'>verification_code</text><title>verification_code varchar&#040;5&#041;</title></a>
+  <a xlink:href='#swabs_per_kit'><text x='63' y='502'>swabs_per_kit</text><title>swabs_per_kit bigint</title></a>
+  <a xlink:href='#print_results'><text x='63' y='517'>print_results</text><title>print_results varchar&#040;1&#041; default &#039;n&#039;&#058;&#058;character varying</title></a>
+  <use id='nn' x='47' y='522' xlink:href='#nn'/><a xlink:href='#created_on'><text x='63' y='532'>created_on</text><title>created_on timestamp not null default current&#095;timestamp</title></a>
+
+<!-- ============= Table 'ag_handout_barcodes' ============= -->
 <rect class='table' x='255' y='413' width='150' height='90' rx='7' ry='7' />
 <path d='M 255.50 439.50 L 255.50 420.50 Q 255.50 413.50 262.50 413.50 L 397.50 413.50 Q 404.50 413.50 404.50 420.50 L 404.50 439.50 L255.50 439.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
-<a xlink:href='#handout_barcode'><text x='282' y='427' class='tableTitle'>handout_barcode</text><title>Table ag.handout_barcode</title></a>
+<a xlink:href='#ag_handout_barcodes'><text x='270' y='427' class='tableTitle'>ag_handout_barcodes</text><title>Table ag.ag_handout_barcodes</title></a>
   <use id='nn' x='257' y='447' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='257' y='446' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) Index  ( kit_id ) </title></a>
 <a xlink:href='#kit_id'><text x='273' y='457'>kit_id</text><title>kit_id varchar not null</title></a>
 <a xlink:href='#kit_id'><use id='fk' x='393' y='446' xlink:href='#fk'/><title>References ag_handout_kits ( kit_id ) </title></a>
@@ -1030,19 +1043,6 @@ Referred by project_barcode ( barcode ) </title></a>
 <a xlink:href='#barcode'><text x='273' y='472'>barcode</text><title>barcode varchar&#040;9&#041; not null</title></a>
 <a xlink:href='#barcode'><use id='fk' x='393' y='461' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
   <use id='nn' x='257' y='477' xlink:href='#nn'/><a xlink:href='#sample_barcode_file'><text x='273' y='487'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;13&#041; not null</title></a>
-
-<!-- ============= Table 'ag_handout_kits' ============= -->
-<rect class='table' x='45' y='413' width='135' height='135' rx='7' ry='7' />
-<path d='M 45.50 439.50 L 45.50 420.50 Q 45.50 413.50 52.50 413.50 L 172.50 413.50 Q 179.50 413.50 179.50 420.50 L 179.50 439.50 L45.50 439.50 ' style='fill:url(#tableHeaderGradient7); stroke:none;' />
-<a xlink:href='#ag_handout_kits'><text x='68' y='427' class='tableTitle'>ag_handout_kits</text><title>Table ag.ag_handout_kits</title></a>
-  <use id='nn' x='47' y='447' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='47' y='446' xlink:href='#pk'/><title>Primary Key  ( kit_id ) </title></a>
-<a xlink:href='#kit_id'><text x='63' y='457'>kit_id</text><title>kit_id varchar&#040;9&#041; not null</title></a>
-<a xlink:href='#kit_id'><use id='ref' x='168' y='446' xlink:href='#ref'/><title>Referred by handout_barcode ( kit_id ) </title></a>
-  <a xlink:href='#password'><text x='63' y='472'>password</text><title>password varchar&#040;11&#041;</title></a>
-  <a xlink:href='#verification_code'><text x='63' y='487'>verification_code</text><title>verification_code varchar&#040;5&#041;</title></a>
-  <a xlink:href='#swabs_per_kit'><text x='63' y='502'>swabs_per_kit</text><title>swabs_per_kit bigint</title></a>
-  <a xlink:href='#print_results'><text x='63' y='517'>print_results</text><title>print_results varchar&#040;1&#041; default &#039;n&#039;&#058;&#058;character varying</title></a>
-  <use id='nn' x='47' y='522' xlink:href='#nn'/><a xlink:href='#created_on'><text x='63' y='532'>created_on</text><title>created_on timestamp not null default current&#095;timestamp</title></a>
 
 </g></svg>
 
@@ -3285,7 +3285,51 @@ Referred by project_barcode ( barcode ) </title></a>
 <br/><br/>
 <table id='dbs' >
 <thead>
-<tr><th colspan='3'><a name='handout_barcode'>handout_barcode</a></th></tr>
+<tr><th colspan='3'><a name='ag_handout_kits'>ag_handout_kits</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='kit_id'>kit&#095;id</a></td>
+		<td width='40%'> varchar&#040; 9 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='password'>password</a></td>
+		<td width='40%'> varchar&#040; 11 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='verification_code'>verification&#095;code</a></td>
+		<td width='40%'> varchar&#040; 5 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='swabs_per_kit'>swabs&#095;per&#095;kit</a></td>
+		<td width='40%'> bigint   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='print_results'>print&#095;results</a></td>
+		<td width='40%'> varchar&#040; 1 &#041;   DEFO 'n'::character varying </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='created_on'>created&#095;on</a></td>
+		<td width='40%'> timestamp  NOT NULL  DEFO current_timestamp </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>pk&#095;ag&#095;handout&#095;kits primary key</td>
+		<td> ON kit&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='ag_handout_barcodes'>ag_handout_barcodes</a></th></tr>
 </thead>
 <tbody>
 	<tr>
@@ -3325,50 +3369,6 @@ Referred by project_barcode ( barcode ) </title></a>
 	<tr>
 		<td>fk_handout_barcode_0</td>
 		<td > ( kit&#095;id ) ref <a href='#ag&#095;handout&#095;kits'>ag&#095;handout&#095;kits</a> (kit&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='ag_handout_kits'>ag_handout_kits</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='kit_id'>kit&#095;id</a></td>
-		<td width='40%'> varchar&#040; 9 &#041;  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='password'>password</a></td>
-		<td width='40%'> varchar&#040; 11 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='verification_code'>verification&#095;code</a></td>
-		<td width='40%'> varchar&#040; 5 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='swabs_per_kit'>swabs&#095;per&#095;kit</a></td>
-		<td width='40%'> bigint   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='print_results'>print&#095;results</a></td>
-		<td width='40%'> varchar&#040; 1 &#041;   DEFO 'n'::character varying </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='created_on'>created&#095;on</a></td>
-		<td width='40%'> timestamp  NOT NULL  DEFO current_timestamp </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>pk&#095;ag&#095;handout&#095;kits primary key</td>
-		<td> ON kit&#095;id</td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/amgut/db/ag.html
+++ b/amgut/db/ag.html
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'   width='1935' height='2285' viewbox='0 0 1935 2285' >
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'   width='1890' height='2285' viewbox='0 0 1890 2285' >
 <style type='text/css'>
   text                { fill:#000000; font-family: Dialog, Dialog, Arial; font-size:11px; stroke:#000000; stroke-width:0.1; }
   text:hover          { fill:#a00000; font-size:12px;}
@@ -36,32 +36,32 @@
 	   <stop offset='0%' stop-color='#ffffff' />
     <stop offset='100%' stop-color='#efefef' />
   </radialGradient>
-  <linearGradient id='tableHeaderGradient0' x1='0%' y1='0%' x2='0%' y2='90%' >
+  <linearGradient id='tableHeaderGradient6' x1='0%' y1='0%' x2='0%' y2='90%' >
           <stop offset='0%' stop-color='white'/> 
           <stop offset='30%' stop-color='white'/> 
           <stop offset='100%' stop-color='#cef7c6'/> 
    </linearGradient>
-  <linearGradient id='tableHeaderGradient5' x1='0%' y1='0%' x2='0%' y2='90%' >
+  <linearGradient id='tableHeaderGradient4' x1='0%' y1='0%' x2='0%' y2='90%' >
           <stop offset='0%' stop-color='white'/> 
           <stop offset='30%' stop-color='white'/> 
           <stop offset='100%' stop-color='#a8c4ef'/> 
    </linearGradient>
-  <linearGradient id='tableHeaderGradient6' x1='0%' y1='0%' x2='0%' y2='90%' >
+  <linearGradient id='tableHeaderGradient5' x1='0%' y1='0%' x2='0%' y2='90%' >
           <stop offset='0%' stop-color='white'/> 
           <stop offset='30%' stop-color='white'/> 
           <stop offset='100%' stop-color='#c6d9f7'/> 
    </linearGradient>
-  <linearGradient id='tableHeaderGradient1' x1='0%' y1='0%' x2='0%' y2='90%' >
+  <linearGradient id='tableHeaderGradient0' x1='0%' y1='0%' x2='0%' y2='90%' >
           <stop offset='0%' stop-color='white'/> 
           <stop offset='30%' stop-color='white'/> 
           <stop offset='100%' stop-color='#f7e2c6'/> 
    </linearGradient>
-  <linearGradient id='tableHeaderGradient3' x1='0%' y1='0%' x2='0%' y2='90%' >
+  <linearGradient id='tableHeaderGradient2' x1='0%' y1='0%' x2='0%' y2='90%' >
           <stop offset='0%' stop-color='white'/> 
           <stop offset='30%' stop-color='white'/> 
           <stop offset='100%' stop-color='#ffcccc'/> 
    </linearGradient>
-  <linearGradient id='tableHeaderGradient2' x1='0%' y1='0%' x2='0%' y2='90%' >
+  <linearGradient id='tableHeaderGradient1' x1='0%' y1='0%' x2='0%' y2='90%' >
           <stop offset='0%' stop-color='white'/> 
           <stop offset='30%' stop-color='white'/> 
           <stop offset='100%' stop-color='#c6c6f7'/> 
@@ -71,7 +71,7 @@
           <stop offset='30%' stop-color='white'/> 
           <stop offset='100%' stop-color='#ccccff'/> 
    </linearGradient>
-  <linearGradient id='tableHeaderGradient4' x1='0%' y1='0%' x2='0%' y2='90%' >
+  <linearGradient id='tableHeaderGradient3' x1='0%' y1='0%' x2='0%' y2='90%' >
           <stop offset='0%' stop-color='white'/> 
           <stop offset='30%' stop-color='white'/> 
           <stop offset='100%' stop-color='#ffffff'/> 
@@ -175,7 +175,7 @@
 </defs>
 
 <!-- ============= Desktop ============= -->
-<rect x='1' y='1' width='1933' height='2283' rx='7' ry='7' style='fill:white; stroke:#104576; stroke-width:0.5;' />
+<rect x='1' y='1' width='1888' height='2283' rx='7' ry='7' style='fill:white; stroke:#104576; stroke-width:0.5;' />
 
 <!-- ============= Legend ============= -->
 <g transform='translate(10,10)'>
@@ -188,676 +188,676 @@
 
 <g transform='translate(0,110)'>
 <!-- ============= Group 'ag_survey_multiples' ============= -->
-<rect class='grp' style='fill:#faf6f0;' x='704' y='250' width='632' height='995' />
-<text x='715' y='265'>ag_survey_multiples</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='715' y='268' width='610' height='2' />
+<rect class='grp' style='fill:#faf6f0;' x='659' y='250' width='632' height='995' />
+<text x='670' y='265'>ag_survey_multiples</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='670' y='268' width='610' height='2' />
 
 <!-- ============= Group 'disconnected tables' ============= -->
-<rect class='grp' style='fill:#f2faf0;' x='29' y='280' width='572' height='290' />
-<text x='40' y='295'>disconnected tables</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='40' y='298' width='550' height='2' />
+<rect class='grp' style='fill:#f2faf0;' x='44' y='55' width='557' height='275' />
+<text x='55' y='70'>disconnected tables</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='55' y='73' width='535' height='2' />
 
 <!-- ============= Group 'american_gut_consent' ============= -->
-<rect class='grp' style='fill:#f0f4fa;' x='1334' y='385' width='572' height='1760' />
-<text x='1345' y='400'>american_gut_consent</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1345' y='403' width='550' height='2' />
+<rect class='grp' style='fill:#f0f4fa;' x='1289' y='385' width='572' height='1760' />
+<text x='1300' y='400'>american_gut_consent</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='1300' y='403' width='550' height='2' />
 
 <!-- ============= Group 'controlled_vocab_values' ============= -->
-<rect class='grp' style='fill:#f0f0fa;' x='704' y='10' width='572' height='215' />
-<text x='715' y='25'>controlled_vocab_values</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='715' y='28' width='550' height='2' />
+<rect class='grp' style='fill:#f0f0fa;' x='659' y='10' width='572' height='215' />
+<text x='670' y='25'>controlled_vocab_values</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='670' y='28' width='550' height='2' />
 
 <!-- ============= Group 'survey_questions' ============= -->
-<rect class='grp' style='fill:#c4e0f9;' x='74' y='1330' width='1127' height='485' />
-<text x='85' y='1345'>survey_questions</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='85' y='1348' width='1105' height='2' />
+<rect class='grp' style='fill:#c4e0f9;' x='29' y='1330' width='1127' height='485' />
+<text x='40' y='1345'>survey_questions</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='40' y='1348' width='1105' height='2' />
 
 <!-- ============= Group 'Group_barcode' ============= -->
-<rect class='grp' style='fill:#c4e0f9;' x='74' y='595' width='527' height='635' />
-<text x='85' y='610'>Group_barcode</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='85' y='613' width='505' height='2' />
+<rect class='grp' style='fill:#c4e0f9;' x='29' y='595' width='527' height='635' />
+<text x='40' y='610'>Group_barcode</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='40' y='613' width='505' height='2' />
 
-<path transform='translate(7,0)' marker-start='url(#foot)'     d='M 870 720 L 877,720 Q 885,720 885,712 L 885,630' >
+<!-- ============= Group 'Group_handout_kits' ============= -->
+<rect class='grp' style='fill:#c4e0f9;' x='29' y='385' width='392' height='185' />
+<text x='40' y='400'>Group_handout_kits</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='40' y='403' width='370' height='2' />
+
+<path transform='translate(7,0)' marker-start='url(#foot)'     d='M 825 720 L 832,720 Q 840,720 840,712 L 840,630' >
 	<title>Foreign Key fk_sur_an_to_ag_login
 	ag_survey_answer references ag_login ( ag_login_id )</title>
 </path>
-<text x='877' y='715' transform='rotate(0 877,715)' title='Foreign Key fk_sur_an_to_ag_login
-	ag_survey_answer references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 915 90 L 892,90 Q 885,90 885,82 L 885,82 Q 885,75 877,75 L 870,75' >
+<text x='832' y='715' transform='rotate(0 832,715)' title='Foreign Key fk_sur_an_to_ag_login
+	ag_survey_answer references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 870 90 L 847,90 Q 840,90 840,82 L 840,82 Q 840,75 832,75 L 825,75' >
 	<title>Foreign Key fk_cont_vcb_values_cont_vcbs
 	controlled_vocab_values references controlled_vocabs ( controlled_vocab_id )</title>
 </path>
-<text x='808' y='85' transform='rotate(0 808,85)' title='Foreign Key fk_cont_vcb_values_cont_vcbs
-	controlled_vocab_values references controlled_vocabs ( controlled_vocab_id )' style='fill:#a1a0a0;'>controlled_vocab_id</text><path transform='translate(7,0)' marker-start='url(#foot)'   style='stroke-dasharray:4,2;'  d='M 1110 345 L 1102,345 Q 1095,345 1095,352 L 1095,465' >
+<text x='763' y='85' transform='rotate(0 763,85)' title='Foreign Key fk_cont_vcb_values_cont_vcbs
+	controlled_vocab_values references controlled_vocabs ( controlled_vocab_id )' style='fill:#a1a0a0;'>controlled_vocab_id</text><path transform='translate(7,0)' marker-start='url(#foot)'   style='stroke-dasharray:4,2;'  d='M 1065 345 L 1057,345 Q 1050,345 1050,352 L 1050,465' >
 	<title>Foreign Key fk_ag_participant_exceptions
 	ag_participant_exceptions references ag_login ( ag_login_id )</title>
 </path>
-<text x='1050' y='340' transform='rotate(0 1050,340)' title='Foreign Key fk_ag_participant_exceptions
-	ag_participant_exceptions references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 915 315 L 892,315 Q 885,315 885,322 L 885,427 Q 885,435 877,435 L 870,435' >
+<text x='1005' y='340' transform='rotate(0 1005,340)' title='Foreign Key fk_ag_participant_exceptions
+	ag_participant_exceptions references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 870 315 L 847,315 Q 840,315 840,322 L 840,427 Q 840,435 832,435 L 825,435' >
 	<title>Foreign Key fk_ag_animal_surv_to_ag_login
 	ag_animal_survey references ag_login ( ag_login_id )</title>
 </path>
-<text x='855' y='310' transform='rotate(0 855,310)' title='Foreign Key fk_ag_animal_surv_to_ag_login
-	ag_animal_survey references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 930 780 L 892,780 Q 885,780 885,772 L 885,705' >
+<text x='810' y='310' transform='rotate(0 810,310)' title='Foreign Key fk_ag_animal_surv_to_ag_login
+	ag_animal_survey references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 885 780 L 847,780 Q 840,780 840,772 L 840,705' >
 	<title>Foreign Key fk_ag_mul_to_ag_login
 	ag_survey_multiples references ag_login ( ag_login_id )</title>
 </path>
-<text x='870' y='775' transform='rotate(0 870,775)' title='Foreign Key fk_ag_mul_to_ag_login
-	ag_survey_multiples references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 330 1395 L 195,1395' >
+<text x='825' y='775' transform='rotate(0 825,775)' title='Foreign Key fk_ag_mul_to_ag_login
+	ag_survey_multiples references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 285 1395 L 150,1395' >
 	<title>Foreign Key fk_human_survey_group_question
 	group_questions references survey_group ( survey_group -> group_order )</title>
 </path>
-<text x='257' y='1390' transform='rotate(0 257,1390)' title='Foreign Key fk_human_survey_group_question
-	group_questions references survey_group ( survey_group -> group_order )' style='fill:#a1a0a0;'>survey_group</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 480 1410 L 622,1410 Q 630,1410 630,1417 L 630,1552 Q 630,1560 622,1560 L 615,1560' >
+<text x='212' y='1390' transform='rotate(0 212,1390)' title='Foreign Key fk_human_survey_group_question
+	group_questions references survey_group ( survey_group -> group_order )' style='fill:#a1a0a0;'>survey_group</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 435 1410 L 577,1410 Q 585,1410 585,1417 L 585,1552 Q 585,1560 577,1560 L 570,1560' >
 	<title>Foreign Key fk_human_survey_group_question_0
 	group_questions references survey_question ( survey_question_id )</title>
 </path>
-<text x='487' y='1405' transform='rotate(0 487,1405)' title='Foreign Key fk_human_survey_group_question_0
-	group_questions references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 195 1575 L 202,1575 Q 210,1575 210,1567 L 210,1402 Q 210,1395 202,1395 L 195,1395' >
+<text x='442' y='1405' transform='rotate(0 442,1405)' title='Foreign Key fk_human_survey_group_question_0
+	group_questions references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 150 1575 L 157,1575 Q 165,1575 165,1567 L 165,1402 Q 165,1395 157,1395 L 150,1395' >
 	<title>Foreign Key fk_surveys
 	surveys references survey_group ( survey_group -> group_order )</title>
 </path>
-<text x='202' y='1570' transform='rotate(0 202,1570)' title='Foreign Key fk_surveys
-	surveys references survey_group ( survey_group -> group_order )' style='fill:#a1a0a0;'>survey_group</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1140 735 L 1102,735 Q 1095,735 1095,727 L 1095,652 Q 1095,645 1087,645 L 1080,645' >
+<text x='157' y='1570' transform='rotate(0 157,1570)' title='Foreign Key fk_surveys
+	surveys references survey_group ( survey_group -> group_order )' style='fill:#a1a0a0;'>survey_group</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1095 735 L 1057,735 Q 1050,735 1050,727 L 1050,652 Q 1050,645 1042,645 L 1035,645' >
 	<title>Foreign Key fk_ag_kit_to_login_id
 	ag_kit references ag_login ( ag_login_id )</title>
 </path>
-<text x='1080' y='730' transform='rotate(0 1080,730)' title='Foreign Key fk_ag_kit_to_login_id
-	ag_kit references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1485 1170 L 1537,1170 Q 1545,1170 1545,1162 L 1545,1155' >
+<text x='1035' y='730' transform='rotate(0 1035,730)' title='Foreign Key fk_ag_kit_to_login_id
+	ag_kit references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1440 1170 L 1492,1170 Q 1500,1170 1500,1162 L 1500,1155' >
 	<title>Foreign Key fk_survey_answers_other
 	survey_answers_other references ag_login_surveys ( survey_id )</title>
 </path>
-<text x='1492' y='1165' transform='rotate(0 1492,1165)' title='Foreign Key fk_survey_answers_other
-	survey_answers_other references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1335 1185 L 982,1185 Q 975,1185 975,1192 L 975,1387 Q 975,1395 967,1395 L 637,1395 Q 630,1395 630,1402 L 630,1425' >
+<text x='1447' y='1165' transform='rotate(0 1447,1165)' title='Foreign Key fk_survey_answers_other
+	survey_answers_other references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1290 1185 L 937,1185 Q 930,1185 930,1192 L 930,1387 Q 930,1395 922,1395 L 592,1395 Q 585,1395 585,1402 L 585,1425' >
 	<title>Foreign Key fk_survey_answers_other_0
 	survey_answers_other references survey_question ( survey_question_id )</title>
 </path>
-<text x='1232' y='1180' transform='rotate(0 1232,1180)' title='Foreign Key fk_survey_answers_other_0
-	survey_answers_other references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><path transform='translate(7,0)' marker-start='url(#foot)'   style='stroke-dasharray:4,2;'  d='M 675 1485 L 637,1485 Q 630,1485 630,1492 L 630,1500' >
+<text x='1187' y='1180' transform='rotate(0 1187,1180)' title='Foreign Key fk_survey_answers_other_0
+	survey_answers_other references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><path transform='translate(7,0)' marker-start='url(#foot)'   style='stroke-dasharray:4,2;'  d='M 630 1485 L 592,1485 Q 585,1485 585,1492 L 585,1500' >
 	<title>Foreign Key fk_survey_question_triggers
 	survey_question_triggers references survey_question ( triggered_question -> survey_question_id )</title>
 </path>
-<text x='574' y='1480' transform='rotate(0 574,1480)' title='Foreign Key fk_survey_question_triggers
-	survey_question_triggers references survey_question ( triggered_question -> survey_question_id )' style='fill:#a1a0a0;'>triggered_question</text><path transform='translate(7,0)' marker-start='url(#foot)'   style='stroke-dasharray:4,2;'  d='M 840 1470 L 907,1470 Q 915,1470 915,1477 L 915,1485' >
+<text x='529' y='1480' transform='rotate(0 529,1480)' title='Foreign Key fk_survey_question_triggers
+	survey_question_triggers references survey_question ( triggered_question -> survey_question_id )' style='fill:#a1a0a0;'>triggered_question</text><path transform='translate(7,0)' marker-start='url(#foot)'   style='stroke-dasharray:4,2;'  d='M 795 1470 L 862,1470 Q 870,1470 870,1477 L 870,1485' >
 	<title>Foreign Key fk_survey_question_triggers0
 	survey_question_triggers references survey_question_response ( survey_question_id, triggering_response -> response )</title>
 </path>
-<text x='847' y='1465' transform='rotate(0 847,1465)' title='Foreign Key fk_survey_question_triggers0
-	survey_question_triggers references survey_question_response ( survey_question_id, triggering_response -> response )' style='fill:#a1a0a0;'>survey_question_id,triggering_response</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 720 1575 L 712,1575 Q 705,1575 705,1582 L 705,1657 Q 705,1665 712,1665 L 720,1665' >
+<text x='802' y='1465' transform='rotate(0 802,1465)' title='Foreign Key fk_survey_question_triggers0
+	survey_question_triggers references survey_question_response ( survey_question_id, triggering_response -> response )' style='fill:#a1a0a0;'>survey_question_id,triggering_response</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 675 1575 L 667,1575 Q 660,1575 660,1582 L 660,1657 Q 660,1665 667,1665 L 675,1665' >
 	<title>Foreign Key fk_question_response
 	survey_question_response references survey_response ( response -> american )</title>
 </path>
-<text x='672' y='1570' transform='rotate(0 672,1570)' title='Foreign Key fk_question_response
-	survey_question_response references survey_response ( response -> american )' style='fill:#a1a0a0;'>response</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 720 1560 L 667,1560 Q 660,1560 660,1552 L 660,1492 Q 660,1485 652,1485 L 645,1485' >
+<text x='627' y='1570' transform='rotate(0 627,1570)' title='Foreign Key fk_question_response
+	survey_question_response references survey_response ( response -> american )' style='fill:#a1a0a0;'>response</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 675 1560 L 622,1560 Q 615,1560 615,1552 L 615,1492 Q 615,1485 607,1485 L 600,1485' >
 	<title>Foreign Key fk_question_response_0
 	survey_question_response references survey_question ( survey_question_id )</title>
 </path>
-<text x='617' y='1555' transform='rotate(0 617,1555)' title='Foreign Key fk_question_response_0
-	survey_question_response references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1695 450 L 1102,450 Q 1095,450 1095,457 L 1095,637 Q 1095,645 1087,645 L 892,645 Q 885,645 885,637 L 885,442 Q 885,435 877,435 L 870,435' >
+<text x='572' y='1555' transform='rotate(0 572,1555)' title='Foreign Key fk_question_response_0
+	survey_question_response references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1650 450 L 1057,450 Q 1050,450 1050,457 L 1050,637 Q 1050,645 1042,645 L 847,645 Q 840,645 840,637 L 840,442 Q 840,435 832,435 L 825,435' >
 	<title>Foreign Key fk_ag_hum_surv_to_ag_login
 	ag_human_survey references ag_login ( ag_login_id )</title>
 </path>
-<text x='1635' y='445' transform='rotate(0 1635,445)' title='Foreign Key fk_ag_hum_surv_to_ag_login
-	ag_human_survey references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 930 1665 L 840,1665' >
+<text x='1590' y='445' transform='rotate(0 1590,445)' title='Foreign Key fk_ag_hum_surv_to_ag_login
+	ag_human_survey references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 885 1665 L 795,1665' >
 	<title>Foreign Key fk_iso_country_lookup
 	iso_country_lookup references survey_response ( country -> american )</title>
 </path>
-<text x='890' y='1660' transform='rotate(0 890,1660)' title='Foreign Key fk_iso_country_lookup
-	iso_country_lookup references survey_response ( country -> american )' style='fill:#a1a0a0;'>country</text><path transform='translate(7,0)' marker-start='url(#foot)'   style='stroke-dasharray:4,2;'  d='M 720 1755 L 637,1755 Q 630,1755 630,1747 L 630,1567 Q 630,1560 622,1560 L 615,1560' >
+<text x='845' y='1660' transform='rotate(0 845,1660)' title='Foreign Key fk_iso_country_lookup
+	iso_country_lookup references survey_response ( country -> american )' style='fill:#a1a0a0;'>country</text><path transform='translate(7,0)' marker-start='url(#foot)'   style='stroke-dasharray:4,2;'  d='M 675 1755 L 592,1755 Q 585,1755 585,1747 L 585,1567 Q 585,1560 577,1560 L 570,1560' >
 	<title>Foreign Key fk_human_survey_response_type
 	survey_question_response_type references survey_question ( survey_question_id )</title>
 </path>
-<text x='617' y='1750' transform='rotate(0 617,1750)' title='Foreign Key fk_human_survey_response_type
-	survey_question_response_type references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 930 1770 L 1020,1770' >
+<text x='572' y='1750' transform='rotate(0 572,1750)' title='Foreign Key fk_human_survey_response_type
+	survey_question_response_type references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 885 1770 L 975,1770' >
 	<title>Foreign Key fk_human_survey_question_response_type
 	survey_question_response_type references survey_response_types ( survey_response_type )</title>
 </path>
-<text x='937' y='1765' transform='rotate(0 937,1765)' title='Foreign Key fk_human_survey_question_response_type
-	survey_question_response_type references survey_response_types ( survey_response_type )' style='fill:#a1a0a0;'>survey_response_type</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 960 930 L 1117,930 Q 1125,930 1125,922 L 1125,727 Q 1125,720 1132,720 L 1140,720' >
+<text x='892' y='1765' transform='rotate(0 892,1765)' title='Foreign Key fk_human_survey_question_response_type
+	survey_question_response_type references survey_response_types ( survey_response_type )' style='fill:#a1a0a0;'>survey_response_type</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 915 930 L 1072,930 Q 1080,930 1080,922 L 1080,727 Q 1080,720 1087,720 L 1095,720' >
 	<title>Foreign Key fk_ag_kit_barcodes
 	ag_kit_barcodes references ag_kit ( ag_kit_id )</title>
 </path>
-<text x='967' y='925' transform='rotate(0 967,925)' title='Foreign Key fk_ag_kit_barcodes
-	ag_kit_barcodes references ag_kit ( ag_kit_id )' style='fill:#a1a0a0;'>ag_kit_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 765 945 L 607,945 Q 600,945 600,937 L 600,667 Q 600,660 592,660 L 585,660' >
+<text x='922' y='925' transform='rotate(0 922,925)' title='Foreign Key fk_ag_kit_barcodes
+	ag_kit_barcodes references ag_kit ( ag_kit_id )' style='fill:#a1a0a0;'>ag_kit_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 720 945 L 562,945 Q 555,945 555,937 L 555,667 Q 555,660 547,660 L 540,660' >
 	<title>Foreign Key fk_ag_kit_barcodes_0
 	ag_kit_barcodes references barcode ( barcode )</title>
 </path>
-<text x='723' y='940' transform='rotate(0 723,940)' title='Foreign Key fk_ag_kit_barcodes_0
-	ag_kit_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 960 960 L 1432,960 Q 1440,960 1440,967 L 1440,1057 Q 1440,1065 1447,1065 L 1455,1065' >
+<text x='678' y='940' transform='rotate(0 678,940)' title='Foreign Key fk_ag_kit_barcodes_0
+	ag_kit_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 915 960 L 1387,960 Q 1395,960 1395,967 L 1395,1057 Q 1395,1065 1402,1065 L 1410,1065' >
 	<title>Foreign Key fk_ag_kit_barcodes_1
 	ag_kit_barcodes references ag_login_surveys ( survey_id )</title>
 </path>
-<text x='967' y='955' transform='rotate(0 967,955)' title='Foreign Key fk_ag_kit_barcodes_1
-	ag_kit_barcodes references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1605 1050 L 1627,1050 Q 1635,1050 1635,1042 L 1635,457 Q 1635,450 1627,450 L 1620,450' >
+<text x='922' y='955' transform='rotate(0 922,955)' title='Foreign Key fk_ag_kit_barcodes_1
+	ag_kit_barcodes references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1560 1050 L 1582,1050 Q 1590,1050 1590,1042 L 1590,457 Q 1590,450 1582,450 L 1575,450' >
 	<title>Foreign Key fk_ag_login_surveys
 	ag_login_surveys references ag_login ( ag_login_id )</title>
 </path>
-<text x='1612' y='1045' transform='rotate(0 1612,1045)' title='Foreign Key fk_ag_login_surveys
-	ag_login_surveys references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1560 1260 L 922,1260 Q 915,1260 915,1267 L 915,1567 Q 915,1575 907,1575 L 900,1575' >
+<text x='1567' y='1045' transform='rotate(0 1567,1045)' title='Foreign Key fk_ag_login_surveys
+	ag_login_surveys references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1515 1260 L 877,1260 Q 870,1260 870,1267 L 870,1567 Q 870,1575 862,1575 L 855,1575' >
 	<title>Foreign Key fk_survey_answers
 	survey_answers references survey_question_response ( survey_question_id, response )</title>
 </path>
-<text x='1404' y='1255' transform='rotate(0 1404,1255)' title='Foreign Key fk_survey_answers
-	survey_answers references survey_question_response ( survey_question_id, response )' style='fill:#a1a0a0;'>survey_question_id,response</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1560 1230 L 1552,1230 Q 1545,1230 1545,1222 L 1545,1147 Q 1545,1140 1552,1140 L 1612,1140 Q 1620,1140 1620,1132 L 1620,1072 Q 1620,1065 1612,1065 L 1605,1065' >
+<text x='1359' y='1255' transform='rotate(0 1359,1255)' title='Foreign Key fk_survey_answers
+	survey_answers references survey_question_response ( survey_question_id, response )' style='fill:#a1a0a0;'>survey_question_id,response</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 1515 1230 L 1507,1230 Q 1500,1230 1500,1222 L 1500,1147 Q 1500,1140 1507,1140 L 1567,1140 Q 1575,1140 1575,1132 L 1575,1072 Q 1575,1065 1567,1065 L 1560,1065' >
 	<title>Foreign Key fk_survey_answers_0
 	survey_answers references ag_login_surveys ( survey_id )</title>
 </path>
-<text x='1510' y='1225' transform='rotate(0 1510,1225)' title='Foreign Key fk_survey_answers_0
-	survey_answers references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1455 945 L 1447,945 Q 1440,945 1440,952 L 1440,975' >
+<text x='1465' y='1225' transform='rotate(0 1465,1225)' title='Foreign Key fk_survey_answers_0
+	survey_answers references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1410 945 L 1402,945 Q 1395,945 1395,952 L 1395,975' >
 	<title>Foreign Key fk_promoted_survey_ids
 	promoted_survey_ids references ag_login_surveys ( survey_id )</title>
 </path>
-<text x='1405' y='940' transform='rotate(0 1405,940)' title='Foreign Key fk_promoted_survey_ids
-	promoted_survey_ids references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1470 705 L 1462,705 Q 1455,705 1455,697 L 1455,457 Q 1455,450 1447,450 L 1440,450' >
+<text x='1360' y='940' transform='rotate(0 1360,940)' title='Foreign Key fk_promoted_survey_ids
+	promoted_survey_ids references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1425 705 L 1417,705 Q 1410,705 1410,697 L 1410,457 Q 1410,450 1402,450 L 1395,450' >
 	<title>Foreign Key fk_american_gut_consent
 	ag_consent references ag_login ( ag_login_id )</title>
 </path>
-<text x='1410' y='700' transform='rotate(0 1410,700)' title='Foreign Key fk_american_gut_consent
-	ag_consent references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 435 990 L 397,990 Q 390,990 390,982 L 390,975' >
+<text x='1365' y='700' transform='rotate(0 1365,700)' title='Foreign Key fk_american_gut_consent
+	ag_consent references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 390 990 L 352,990 Q 345,990 345,982 L 345,975' >
 	<title>Foreign Key fk_pb_to_barcode
 	project_barcode references barcode ( barcode )</title>
 </path>
-<text x='393' y='985' transform='rotate(0 393,985)' title='Foreign Key fk_pb_to_barcode
-	project_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 435 975 L 427,975 Q 420,975 420,967 L 420,892 Q 420,885 427,885 L 435,885' >
+<text x='348' y='985' transform='rotate(0 348,985)' title='Foreign Key fk_pb_to_barcode
+	project_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 390 975 L 382,975 Q 375,975 375,967 L 375,892 Q 375,885 382,885 L 390,885' >
 	<title>Foreign Key fk_pb_to_project
 	project_barcode references project ( project_id )</title>
 </path>
-<text x='383' y='970' transform='rotate(0 383,970)' title='Foreign Key fk_pb_to_project
-	project_barcode references project ( project_id )' style='fill:#a1a0a0;'>project_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 435 1185 L 397,1185 Q 390,1185 390,1177 L 390,915' >
+<text x='338' y='970' transform='rotate(0 338,970)' title='Foreign Key fk_pb_to_project
+	project_barcode references project ( project_id )' style='fill:#a1a0a0;'>project_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 390 1185 L 352,1185 Q 345,1185 345,1177 L 345,1080' >
 	<title>Foreign Key fk_plate_barcode
 	plate_barcode references barcode ( barcode )</title>
 </path>
-<text x='393' y='1180' transform='rotate(0 393,1180)' title='Foreign Key fk_plate_barcode
-	plate_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 435 1170 L 412,1170 Q 405,1170 405,1162 L 405,1072 Q 405,1065 412,1065 L 420,1065' >
+<text x='348' y='1180' transform='rotate(0 348,1180)' title='Foreign Key fk_plate_barcode
+	plate_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 390 1170 L 367,1170 Q 360,1170 360,1162 L 360,1072 Q 360,1065 367,1065 L 375,1065' >
 	<title>Foreign Key fk_plate_barcode_0
 	plate_barcode references plate ( plate_id )</title>
 </path>
-<text x='395' y='1165' transform='rotate(0 395,1165)' title='Foreign Key fk_plate_barcode_0
-	plate_barcode references plate ( plate_id )' style='fill:#a1a0a0;'>plate_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 210 1095 L 247,1095 Q 255,1095 255,1087 L 255,937 Q 255,930 262,930 L 270,930' >
+<text x='350' y='1165' transform='rotate(0 350,1165)' title='Foreign Key fk_plate_barcode_0
+	plate_barcode references plate ( plate_id )' style='fill:#a1a0a0;'>plate_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 165 1095 L 337,1095 Q 345,1095 345,1087 L 345,667 Q 345,660 352,660 L 360,660' >
 	<title>Foreign Key fk_barcode_exceptions
 	barcode_exceptions references barcode ( barcode )</title>
 </path>
-<text x='217' y='1090' transform='rotate(0 217,1090)' title='Foreign Key fk_barcode_exceptions
-	barcode_exceptions references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 240 930 L 382,930 Q 390,930 390,922 L 390,667 Q 390,660 397,660 L 405,660' >
-	<title>Foreign Key fk_ag_handout_kits
-	ag_handout_kits references barcode ( barcode )</title>
+<text x='172' y='1090' transform='rotate(0 172,1090)' title='Foreign Key fk_barcode_exceptions
+	barcode_exceptions references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 405 465 L 547,465 Q 555,465 555,472 L 555,652 Q 555,660 547,660 L 540,660' >
+	<title>Foreign Key fk_handout_barcode
+	handout_barcode references barcode ( barcode )</title>
 </path>
-<text x='247' y='925' transform='rotate(0 247,925)' title='Foreign Key fk_ag_handout_kits
-	ag_handout_kits references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><!-- ============= Table 'ag_map_markers' ============= -->
-<rect class='table' x='45' y='308' width='105' height='120' rx='7' ry='7' />
-<path d='M 45.50 334.50 L 45.50 315.50 Q 45.50 308.50 52.50 308.50 L 142.50 308.50 Q 149.50 308.50 149.50 315.50 L 149.50 334.50 L45.50 334.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#ag_map_markers'><text x='51' y='322' class='tableTitle'>ag_map_markers</text><title>Table ag.ag_map_markers</title></a>
-  <a xlink:href='#zipcode'><text x='63' y='352'>zipcode</text><title>zipcode varchar&#040;20&#041;</title></a>
-  <a xlink:href='#latitude'><text x='63' y='367'>latitude</text><title>latitude float8</title></a>
-  <a xlink:href='#longitude'><text x='63' y='382'>longitude</text><title>longitude float8</title></a>
-  <a xlink:href='#marker_color'><text x='63' y='397'>marker_color</text><title>marker_color varchar&#040;10&#041;</title></a>
-  <a xlink:href='#order_by'><text x='63' y='412'>order_by</text><title>order_by bigint</title></a>
-
-<!-- ============= Table 'ag_survey_answer' ============= -->
-<rect class='table' x='720' y='683' width='150' height='120' rx='7' ry='7' />
-<path d='M 720.50 709.50 L 720.50 690.50 Q 720.50 683.50 727.50 683.50 L 862.50 683.50 Q 869.50 683.50 869.50 690.50 L 869.50 709.50 L720.50 709.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#ag_survey_answer'><text x='745' y='697' class='tableTitle'>ag_survey_answer</text><title>Table ag.ag_survey_answer</title></a>
-  <use id='nn' x='722' y='717' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='722' y='716' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, question ) </title></a>
-<a xlink:href='#ag_login_id'><text x='738' y='727'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
-<a xlink:href='#ag_login_id'><use id='fk' x='858' y='716' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
-  <use id='nn' x='722' y='732' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='722' y='731' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, question ) </title></a>
-<a xlink:href='#participant_name'><text x='738' y='742'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
-  <use id='nn' x='722' y='747' xlink:href='#nn'/><a xlink:href='#question'><use id='pk' x='722' y='746' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, question ) </title></a>
-<a xlink:href='#question'><text x='738' y='757'>question</text><title>question varchar&#040;100&#041; not null</title></a>
-  <a xlink:href='#ag_survery_answer_id'><text x='738' y='772'>ag_survery_answer_id</text><title>ag_survery_answer_id uuid default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
-  <a xlink:href='#answer'><text x='738' y='787'>answer</text><title>answer varchar&#040;4000&#041;</title></a>
+<text x='412' y='460' transform='rotate(0 412,460)' title='Foreign Key fk_handout_barcode
+	handout_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 240 450 L 180,450' >
+	<title>Foreign Key fk_handout_barcode_0
+	handout_barcode references ag_handout_kits ( kit_id )</title>
+</path>
+<text x='213' y='445' transform='rotate(0 213,445)' title='Foreign Key fk_handout_barcode_0
+	handout_barcode references ag_handout_kits ( kit_id )' style='fill:#a1a0a0;'>kit_id</text><!-- ============= Table 'ag_survey_answer' ============= -->
+<rect class='table' x='675' y='683' width='150' height='120' rx='7' ry='7' />
+<path d='M 675.50 709.50 L 675.50 690.50 Q 675.50 683.50 682.50 683.50 L 817.50 683.50 Q 824.50 683.50 824.50 690.50 L 824.50 709.50 L675.50 709.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#ag_survey_answer'><text x='700' y='697' class='tableTitle'>ag_survey_answer</text><title>Table ag.ag_survey_answer</title></a>
+  <use id='nn' x='677' y='717' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='677' y='716' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, question ) </title></a>
+<a xlink:href='#ag_login_id'><text x='693' y='727'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
+<a xlink:href='#ag_login_id'><use id='fk' x='813' y='716' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
+  <use id='nn' x='677' y='732' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='677' y='731' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, question ) </title></a>
+<a xlink:href='#participant_name'><text x='693' y='742'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
+  <use id='nn' x='677' y='747' xlink:href='#nn'/><a xlink:href='#question'><use id='pk' x='677' y='746' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, question ) </title></a>
+<a xlink:href='#question'><text x='693' y='757'>question</text><title>question varchar&#040;100&#041; not null</title></a>
+  <a xlink:href='#ag_survery_answer_id'><text x='693' y='772'>ag_survery_answer_id</text><title>ag_survery_answer_id uuid default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
+  <a xlink:href='#answer'><text x='693' y='787'>answer</text><title>answer varchar&#040;4000&#041;</title></a>
 
 <!-- ============= Table 'controlled_vocab_values' ============= -->
-<rect class='table' x='930' y='38' width='150' height='120' rx='7' ry='7' />
-<path d='M 930.50 64.50 L 930.50 45.50 Q 930.50 38.50 937.50 38.50 L 1072.50 38.50 Q 1079.50 38.50 1079.50 45.50 L 1079.50 64.50 L930.50 64.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#controlled_vocab_values'><text x='938' y='52' class='tableTitle'>controlled_vocab_values</text><title>Table ag.controlled_vocab_values</title></a>
-  <use id='nn' x='932' y='72' xlink:href='#nn'/><a xlink:href='#vocab_value_id'><use id='pk' x='932' y='71' xlink:href='#pk'/><title>Primary Key  ( vocab_value_id ) </title></a>
-<a xlink:href='#vocab_value_id'><text x='948' y='82'>vocab_value_id</text><title>vocab_value_id bigint not null</title></a>
-  <use id='nn' x='932' y='87' xlink:href='#nn'/><a xlink:href='#controlled_vocab_id'><text x='948' y='97'>controlled_vocab_id</text><title>controlled_vocab_id bigint not null</title></a>
-<a xlink:href='#controlled_vocab_id'><use id='fk' x='1068' y='86' xlink:href='#fk'/><title>References controlled_vocabs ( controlled_vocab_id ) </title></a>
-  <use id='nn' x='932' y='102' xlink:href='#nn'/><a xlink:href='#term'><text x='948' y='112'>term</text><title>term varchar&#040;500&#041; not null</title></a>
-  <a xlink:href='#order_by'><text x='948' y='127'>order_by</text><title>order_by bigint</title></a>
-  <a xlink:href='#default_item'><text x='948' y='142'>default_item</text><title>default_item char&#040;1&#041;</title></a>
+<rect class='table' x='885' y='38' width='150' height='120' rx='7' ry='7' />
+<path d='M 885.50 64.50 L 885.50 45.50 Q 885.50 38.50 892.50 38.50 L 1027.50 38.50 Q 1034.50 38.50 1034.50 45.50 L 1034.50 64.50 L885.50 64.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
+<a xlink:href='#controlled_vocab_values'><text x='893' y='52' class='tableTitle'>controlled_vocab_values</text><title>Table ag.controlled_vocab_values</title></a>
+  <use id='nn' x='887' y='72' xlink:href='#nn'/><a xlink:href='#vocab_value_id'><use id='pk' x='887' y='71' xlink:href='#pk'/><title>Primary Key  ( vocab_value_id ) </title></a>
+<a xlink:href='#vocab_value_id'><text x='903' y='82'>vocab_value_id</text><title>vocab_value_id bigint not null</title></a>
+  <use id='nn' x='887' y='87' xlink:href='#nn'/><a xlink:href='#controlled_vocab_id'><text x='903' y='97'>controlled_vocab_id</text><title>controlled_vocab_id bigint not null</title></a>
+<a xlink:href='#controlled_vocab_id'><use id='fk' x='1023' y='86' xlink:href='#fk'/><title>References controlled_vocabs ( controlled_vocab_id ) </title></a>
+  <use id='nn' x='887' y='102' xlink:href='#nn'/><a xlink:href='#term'><text x='903' y='112'>term</text><title>term varchar&#040;500&#041; not null</title></a>
+  <a xlink:href='#order_by'><text x='903' y='127'>order_by</text><title>order_by bigint</title></a>
+  <a xlink:href='#default_item'><text x='903' y='142'>default_item</text><title>default_item char&#040;1&#041;</title></a>
 
 <!-- ============= Table 'controlled_vocabs' ============= -->
-<rect class='table' x='720' y='38' width='150' height='75' rx='7' ry='7' />
-<path d='M 720.50 64.50 L 720.50 45.50 Q 720.50 38.50 727.50 38.50 L 862.50 38.50 Q 869.50 38.50 869.50 45.50 L 869.50 64.50 L720.50 64.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#controlled_vocabs'><text x='745' y='52' class='tableTitle'>controlled_vocabs</text><title>Table ag.controlled_vocabs</title></a>
-  <use id='nn' x='722' y='72' xlink:href='#nn'/><a xlink:href='#controlled_vocab_id'><use id='pk' x='722' y='71' xlink:href='#pk'/><title>Primary Key  ( controlled_vocab_id ) </title></a>
-<a xlink:href='#controlled_vocab_id'><text x='738' y='82'>controlled_vocab_id</text><title>controlled_vocab_id bigint not null</title></a>
-<a xlink:href='#controlled_vocab_id'><use id='ref' x='858' y='71' xlink:href='#ref'/><title>Referred by controlled_vocab_values ( controlled_vocab_id ) </title></a>
-  <a xlink:href='#vocab_name'><text x='738' y='97'>vocab_name</text><title>vocab_name varchar&#040;500&#041;</title></a>
+<rect class='table' x='675' y='38' width='150' height='75' rx='7' ry='7' />
+<path d='M 675.50 64.50 L 675.50 45.50 Q 675.50 38.50 682.50 38.50 L 817.50 38.50 Q 824.50 38.50 824.50 45.50 L 824.50 64.50 L675.50 64.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
+<a xlink:href='#controlled_vocabs'><text x='700' y='52' class='tableTitle'>controlled_vocabs</text><title>Table ag.controlled_vocabs</title></a>
+  <use id='nn' x='677' y='72' xlink:href='#nn'/><a xlink:href='#controlled_vocab_id'><use id='pk' x='677' y='71' xlink:href='#pk'/><title>Primary Key  ( controlled_vocab_id ) </title></a>
+<a xlink:href='#controlled_vocab_id'><text x='693' y='82'>controlled_vocab_id</text><title>controlled_vocab_id bigint not null</title></a>
+<a xlink:href='#controlled_vocab_id'><use id='ref' x='813' y='71' xlink:href='#ref'/><title>Referred by controlled_vocab_values ( controlled_vocab_id ) </title></a>
+  <a xlink:href='#vocab_name'><text x='693' y='97'>vocab_name</text><title>vocab_name varchar&#040;500&#041;</title></a>
 
 <!-- ============= Table 'ag_participant_exceptions' ============= -->
-<rect class='table' x='1125' y='308' width='165' height='75' rx='7' ry='7' />
-<path d='M 1125.50 334.50 L 1125.50 315.50 Q 1125.50 308.50 1132.50 308.50 L 1282.50 308.50 Q 1289.50 308.50 1289.50 315.50 L 1289.50 334.50 L1125.50 334.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#ag_participant_exceptions'><text x='1136' y='322' class='tableTitle'>ag_participant_exceptions</text><title>Table ag.ag_participant_exceptions</title></a>
-  <a xlink:href='#ag_login_id'><use id='idx' x='1127' y='341' xlink:href='#idx'/><title>Index  ( ag_login_id ) </title></a>
-<a xlink:href='#ag_login_id'><text x='1143' y='352'>ag_login_id</text><title>ag_login_id uuid</title></a>
-<a xlink:href='#ag_login_id'><use id='fk' x='1278' y='341' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
-  <a xlink:href='#participant_name'><text x='1143' y='367'>participant_name</text><title>participant_name varchar&#040;200&#041;</title></a>
+<rect class='table' x='1080' y='308' width='165' height='75' rx='7' ry='7' />
+<path d='M 1080.50 334.50 L 1080.50 315.50 Q 1080.50 308.50 1087.50 308.50 L 1237.50 308.50 Q 1244.50 308.50 1244.50 315.50 L 1244.50 334.50 L1080.50 334.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#ag_participant_exceptions'><text x='1091' y='322' class='tableTitle'>ag_participant_exceptions</text><title>Table ag.ag_participant_exceptions</title></a>
+  <a xlink:href='#ag_login_id'><use id='idx' x='1082' y='341' xlink:href='#idx'/><title>Index  ( ag_login_id ) </title></a>
+<a xlink:href='#ag_login_id'><text x='1098' y='352'>ag_login_id</text><title>ag_login_id uuid</title></a>
+<a xlink:href='#ag_login_id'><use id='fk' x='1233' y='341' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
+  <a xlink:href='#participant_name'><text x='1098' y='367'>participant_name</text><title>participant_name varchar&#040;200&#041;</title></a>
 
 <!-- ============= Table 'ag_animal_survey' ============= -->
-<rect class='table' x='930' y='278' width='150' height='345' rx='7' ry='7' />
-<path d='M 930.50 304.50 L 930.50 285.50 Q 930.50 278.50 937.50 278.50 L 1072.50 278.50 Q 1079.50 278.50 1079.50 285.50 L 1079.50 304.50 L930.50 304.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#ag_animal_survey'><text x='957' y='292' class='tableTitle'>ag_animal_survey</text><title>Table ag.ag_animal_survey</title></a>
-  <use id='nn' x='932' y='312' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='932' y='311' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
-<a xlink:href='#ag_login_id'><text x='948' y='322'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
-<a xlink:href='#ag_login_id'><use id='fk' x='1068' y='311' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
-  <use id='nn' x='932' y='327' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='932' y='326' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
-<a xlink:href='#participant_name'><text x='948' y='337'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
-  <a xlink:href='#type'><text x='948' y='352'>type</text><title>type varchar&#040;100&#041;</title></a>
-  <a xlink:href='#origin'><text x='948' y='367'>origin</text><title>origin varchar&#040;100&#041;</title></a>
-  <a xlink:href='#age'><text x='948' y='382'>age</text><title>age varchar&#040;100&#041;</title></a>
-  <a xlink:href='#gender'><text x='948' y='397'>gender</text><title>gender varchar&#040;100&#041;</title></a>
-  <a xlink:href='#setting'><text x='948' y='412'>setting</text><title>setting varchar&#040;100&#041;</title></a>
-  <a xlink:href='#weight'><text x='948' y='427'>weight</text><title>weight varchar&#040;100&#041;</title></a>
-  <a xlink:href='#diet'><text x='948' y='442'>diet</text><title>diet varchar&#040;100&#041;</title></a>
-  <a xlink:href='#food_source_store'><text x='948' y='457'>food_source_store</text><title>food_source_store varchar&#040;100&#041;</title></a>
-  <a xlink:href='#food_source_human'><text x='948' y='472'>food_source_human</text><title>food_source_human varchar&#040;100&#041;</title></a>
-  <a xlink:href='#food_source_wild'><text x='948' y='487'>food_source_wild</text><title>food_source_wild varchar&#040;100&#041;</title></a>
-  <a xlink:href='#food_type'><text x='948' y='502'>food_type</text><title>food_type varchar&#040;100&#041;</title></a>
-  <a xlink:href='#organic_food'><text x='948' y='517'>organic_food</text><title>organic_food varchar&#040;100&#041;</title></a>
-  <a xlink:href='#grain_free_food'><text x='948' y='532'>grain_free_food</text><title>grain_free_food varchar&#040;100&#041;</title></a>
-  <a xlink:href='#living_status'><text x='948' y='547'>living_status</text><title>living_status varchar&#040;100&#041;</title></a>
-  <a xlink:href='#outside_time'><text x='948' y='562'>outside_time</text><title>outside_time varchar&#040;100&#041;</title></a>
-  <a xlink:href='#toilet'><text x='948' y='577'>toilet</text><title>toilet varchar&#040;100&#041;</title></a>
-  <a xlink:href='#coprophage'><text x='948' y='592'>coprophage</text><title>coprophage varchar&#040;100&#041;</title></a>
-  <a xlink:href='#comments'><text x='948' y='607'>comments</text><title>comments varchar&#040;2000&#041;</title></a>
+<rect class='table' x='885' y='278' width='150' height='345' rx='7' ry='7' />
+<path d='M 885.50 304.50 L 885.50 285.50 Q 885.50 278.50 892.50 278.50 L 1027.50 278.50 Q 1034.50 278.50 1034.50 285.50 L 1034.50 304.50 L885.50 304.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#ag_animal_survey'><text x='912' y='292' class='tableTitle'>ag_animal_survey</text><title>Table ag.ag_animal_survey</title></a>
+  <use id='nn' x='887' y='312' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='887' y='311' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
+<a xlink:href='#ag_login_id'><text x='903' y='322'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
+<a xlink:href='#ag_login_id'><use id='fk' x='1023' y='311' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
+  <use id='nn' x='887' y='327' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='887' y='326' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
+<a xlink:href='#participant_name'><text x='903' y='337'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
+  <a xlink:href='#type'><text x='903' y='352'>type</text><title>type varchar&#040;100&#041;</title></a>
+  <a xlink:href='#origin'><text x='903' y='367'>origin</text><title>origin varchar&#040;100&#041;</title></a>
+  <a xlink:href='#age'><text x='903' y='382'>age</text><title>age varchar&#040;100&#041;</title></a>
+  <a xlink:href='#gender'><text x='903' y='397'>gender</text><title>gender varchar&#040;100&#041;</title></a>
+  <a xlink:href='#setting'><text x='903' y='412'>setting</text><title>setting varchar&#040;100&#041;</title></a>
+  <a xlink:href='#weight'><text x='903' y='427'>weight</text><title>weight varchar&#040;100&#041;</title></a>
+  <a xlink:href='#diet'><text x='903' y='442'>diet</text><title>diet varchar&#040;100&#041;</title></a>
+  <a xlink:href='#food_source_store'><text x='903' y='457'>food_source_store</text><title>food_source_store varchar&#040;100&#041;</title></a>
+  <a xlink:href='#food_source_human'><text x='903' y='472'>food_source_human</text><title>food_source_human varchar&#040;100&#041;</title></a>
+  <a xlink:href='#food_source_wild'><text x='903' y='487'>food_source_wild</text><title>food_source_wild varchar&#040;100&#041;</title></a>
+  <a xlink:href='#food_type'><text x='903' y='502'>food_type</text><title>food_type varchar&#040;100&#041;</title></a>
+  <a xlink:href='#organic_food'><text x='903' y='517'>organic_food</text><title>organic_food varchar&#040;100&#041;</title></a>
+  <a xlink:href='#grain_free_food'><text x='903' y='532'>grain_free_food</text><title>grain_free_food varchar&#040;100&#041;</title></a>
+  <a xlink:href='#living_status'><text x='903' y='547'>living_status</text><title>living_status varchar&#040;100&#041;</title></a>
+  <a xlink:href='#outside_time'><text x='903' y='562'>outside_time</text><title>outside_time varchar&#040;100&#041;</title></a>
+  <a xlink:href='#toilet'><text x='903' y='577'>toilet</text><title>toilet varchar&#040;100&#041;</title></a>
+  <a xlink:href='#coprophage'><text x='903' y='592'>coprophage</text><title>coprophage varchar&#040;100&#041;</title></a>
+  <a xlink:href='#comments'><text x='903' y='607'>comments</text><title>comments varchar&#040;2000&#041;</title></a>
 
 <!-- ============= Table 'ag_survey_multiples' ============= -->
-<rect class='table' x='945' y='743' width='135' height='105' rx='7' ry='7' />
-<path d='M 945.50 769.50 L 945.50 750.50 Q 945.50 743.50 952.50 743.50 L 1072.50 743.50 Q 1079.50 743.50 1079.50 750.50 L 1079.50 769.50 L945.50 769.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#ag_survey_multiples'><text x='957' y='757' class='tableTitle'>ag_survey_multiples</text><title>Table ag.ag_survey_multiples</title></a>
-  <use id='nn' x='947' y='777' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='947' y='776' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, item_name ) </title></a>
-<a xlink:href='#ag_login_id'><text x='963' y='787'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
-<a xlink:href='#ag_login_id'><use id='fk' x='1068' y='776' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
-  <use id='nn' x='947' y='792' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='947' y='791' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, item_name ) </title></a>
-<a xlink:href='#participant_name'><text x='963' y='802'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
-  <use id='nn' x='947' y='807' xlink:href='#nn'/><a xlink:href='#item_name'><use id='pk' x='947' y='806' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, item_name ) </title></a>
-<a xlink:href='#item_name'><text x='963' y='817'>item_name</text><title>item_name varchar&#040;50&#041; not null</title></a>
-  <a xlink:href='#item_value'><text x='963' y='832'>item_value</text><title>item_value varchar&#040;1000&#041;</title></a>
+<rect class='table' x='900' y='743' width='135' height='105' rx='7' ry='7' />
+<path d='M 900.50 769.50 L 900.50 750.50 Q 900.50 743.50 907.50 743.50 L 1027.50 743.50 Q 1034.50 743.50 1034.50 750.50 L 1034.50 769.50 L900.50 769.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#ag_survey_multiples'><text x='912' y='757' class='tableTitle'>ag_survey_multiples</text><title>Table ag.ag_survey_multiples</title></a>
+  <use id='nn' x='902' y='777' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='902' y='776' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, item_name ) </title></a>
+<a xlink:href='#ag_login_id'><text x='918' y='787'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
+<a xlink:href='#ag_login_id'><use id='fk' x='1023' y='776' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
+  <use id='nn' x='902' y='792' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='902' y='791' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, item_name ) </title></a>
+<a xlink:href='#participant_name'><text x='918' y='802'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
+  <use id='nn' x='902' y='807' xlink:href='#nn'/><a xlink:href='#item_name'><use id='pk' x='902' y='806' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, item_name ) </title></a>
+<a xlink:href='#item_name'><text x='918' y='817'>item_name</text><title>item_name varchar&#040;50&#041; not null</title></a>
+  <a xlink:href='#item_value'><text x='918' y='832'>item_value</text><title>item_value varchar&#040;1000&#041;</title></a>
 
 <!-- ============= Table 'group_questions' ============= -->
-<rect class='table' x='345' y='1358' width='135' height='90' rx='7' ry='7' />
-<path d='M 345.50 1384.50 L 345.50 1365.50 Q 345.50 1358.50 352.50 1358.50 L 472.50 1358.50 Q 479.50 1358.50 479.50 1365.50 L 479.50 1384.50 L345.50 1384.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
-<a xlink:href='#group_questions'><text x='366' y='1372' class='tableTitle'>group_questions</text><title>Table ag.group_questions</title></a>
-  <use id='nn' x='347' y='1392' xlink:href='#nn'/><a xlink:href='#survey_group'><use id='pk' x='347' y='1391' xlink:href='#pk'/><title>Primary Key  ( survey_group, survey_question_id ) Index  ( survey_group ) Unique Index  ( survey_group, display_index ) </title></a>
-<a xlink:href='#survey_group'><text x='363' y='1402'>survey_group</text><title>survey_group integer not null</title></a>
-<a xlink:href='#survey_group'><use id='fk' x='468' y='1391' xlink:href='#fk'/><title>References survey_group ( survey_group -> group_order ) </title></a>
-  <use id='nn' x='347' y='1407' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='347' y='1406' xlink:href='#pk'/><title>Primary Key  ( survey_group, survey_question_id ) Index  ( survey_question_id ) </title></a>
-<a xlink:href='#survey_question_id'><text x='363' y='1417'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
-<a xlink:href='#survey_question_id'><use id='fk' x='468' y='1406' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
-  <use id='nn' x='347' y='1422' xlink:href='#nn'/><a xlink:href='#display_index'><use id='unq' x='347' y='1421' xlink:href='#unq'/><title>Unique Index  ( survey_group, display_index ) </title></a>
-<a xlink:href='#display_index'><text x='363' y='1432'>display_index</text><title>display_index integer not null</title></a>
+<rect class='table' x='300' y='1358' width='135' height='90' rx='7' ry='7' />
+<path d='M 300.50 1384.50 L 300.50 1365.50 Q 300.50 1358.50 307.50 1358.50 L 427.50 1358.50 Q 434.50 1358.50 434.50 1365.50 L 434.50 1384.50 L300.50 1384.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#group_questions'><text x='321' y='1372' class='tableTitle'>group_questions</text><title>Table ag.group_questions</title></a>
+  <use id='nn' x='302' y='1392' xlink:href='#nn'/><a xlink:href='#survey_group'><use id='pk' x='302' y='1391' xlink:href='#pk'/><title>Primary Key  ( survey_group, survey_question_id ) Index  ( survey_group ) Unique Index  ( survey_group, display_index ) </title></a>
+<a xlink:href='#survey_group'><text x='318' y='1402'>survey_group</text><title>survey_group integer not null</title></a>
+<a xlink:href='#survey_group'><use id='fk' x='423' y='1391' xlink:href='#fk'/><title>References survey_group ( survey_group -> group_order ) </title></a>
+  <use id='nn' x='302' y='1407' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='302' y='1406' xlink:href='#pk'/><title>Primary Key  ( survey_group, survey_question_id ) Index  ( survey_question_id ) </title></a>
+<a xlink:href='#survey_question_id'><text x='318' y='1417'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
+<a xlink:href='#survey_question_id'><use id='fk' x='423' y='1406' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
+  <use id='nn' x='302' y='1422' xlink:href='#nn'/><a xlink:href='#display_index'><use id='unq' x='302' y='1421' xlink:href='#unq'/><title>Unique Index  ( survey_group, display_index ) </title></a>
+<a xlink:href='#display_index'><text x='318' y='1432'>display_index</text><title>display_index integer not null</title></a>
 
 <!-- ============= Table 'survey_response_types' ============= -->
-<rect class='table' x='1035' y='1733' width='150' height='60' rx='7' ry='7' />
-<path d='M 1035.50 1759.50 L 1035.50 1740.50 Q 1035.50 1733.50 1042.50 1733.50 L 1177.50 1733.50 Q 1184.50 1733.50 1184.50 1740.50 L 1184.50 1759.50 L1035.50 1759.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
-<a xlink:href='#survey_response_types'><text x='1046' y='1747' class='tableTitle'>survey_response_types</text><title>Table ag.survey_response_types
+<rect class='table' x='990' y='1733' width='150' height='60' rx='7' ry='7' />
+<path d='M 990.50 1759.50 L 990.50 1740.50 Q 990.50 1733.50 997.50 1733.50 L 1132.50 1733.50 Q 1139.50 1733.50 1139.50 1740.50 L 1139.50 1759.50 L990.50 1759.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
+<a xlink:href='#survey_response_types'><text x='1001' y='1747' class='tableTitle'>survey_response_types</text><title>Table ag.survey_response_types
 Stores every possible type of response&#046;  The response type will be processed in python to determine how the question is represented in the interface&#046;</title></a>
-  <use id='nn' x='1037' y='1767' xlink:href='#nn'/><a xlink:href='#survey_response_type'><use id='pk' x='1037' y='1766' xlink:href='#pk'/><title>Primary Key  ( survey_response_type ) </title></a>
-<a xlink:href='#survey_response_type'><text x='1053' y='1777'>survey_response_type</text><title>survey_response_type varchar not null</title></a>
-<a xlink:href='#survey_response_type'><use id='ref' x='1173' y='1766' xlink:href='#ref'/><title>Referred by survey_question_response_type ( survey_response_type ) </title></a>
+  <use id='nn' x='992' y='1767' xlink:href='#nn'/><a xlink:href='#survey_response_type'><use id='pk' x='992' y='1766' xlink:href='#pk'/><title>Primary Key  ( survey_response_type ) </title></a>
+<a xlink:href='#survey_response_type'><text x='1008' y='1777'>survey_response_type</text><title>survey_response_type varchar not null</title></a>
+<a xlink:href='#survey_response_type'><use id='ref' x='1128' y='1766' xlink:href='#ref'/><title>Referred by survey_question_response_type ( survey_response_type ) </title></a>
 
 <!-- ============= Table 'surveys' ============= -->
-<rect class='table' x='90' y='1523' width='105' height='75' rx='7' ry='7' />
-<path d='M 90.50 1549.50 L 90.50 1530.50 Q 90.50 1523.50 97.50 1523.50 L 187.50 1523.50 Q 194.50 1523.50 194.50 1530.50 L 194.50 1549.50 L90.50 1549.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#surveys'><text x='121' y='1537' class='tableTitle'>surveys</text><title>Table ag.surveys</title></a>
-  <use id='nn' x='92' y='1557' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='92' y='1556' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_group ) </title></a>
-<a xlink:href='#survey_id'><text x='108' y='1567'>survey_id</text><title>survey_id integer not null</title></a>
-  <use id='nn' x='92' y='1572' xlink:href='#nn'/><a xlink:href='#survey_group'><use id='pk' x='92' y='1571' xlink:href='#pk'/><title>Index  ( survey_group ) Primary Key  ( survey_id, survey_group ) </title></a>
-<a xlink:href='#survey_group'><text x='108' y='1582'>survey_group</text><title>survey_group integer not null</title></a>
-<a xlink:href='#survey_group'><use id='fk' x='183' y='1571' xlink:href='#fk'/><title>References survey_group ( survey_group -> group_order ) </title></a>
+<rect class='table' x='45' y='1523' width='105' height='75' rx='7' ry='7' />
+<path d='M 45.50 1549.50 L 45.50 1530.50 Q 45.50 1523.50 52.50 1523.50 L 142.50 1523.50 Q 149.50 1523.50 149.50 1530.50 L 149.50 1549.50 L45.50 1549.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#surveys'><text x='76' y='1537' class='tableTitle'>surveys</text><title>Table ag.surveys</title></a>
+  <use id='nn' x='47' y='1557' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='47' y='1556' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_group ) </title></a>
+<a xlink:href='#survey_id'><text x='63' y='1567'>survey_id</text><title>survey_id integer not null</title></a>
+  <use id='nn' x='47' y='1572' xlink:href='#nn'/><a xlink:href='#survey_group'><use id='pk' x='47' y='1571' xlink:href='#pk'/><title>Index  ( survey_group ) Primary Key  ( survey_id, survey_group ) </title></a>
+<a xlink:href='#survey_group'><text x='63' y='1582'>survey_group</text><title>survey_group integer not null</title></a>
+<a xlink:href='#survey_group'><use id='fk' x='138' y='1571' xlink:href='#fk'/><title>References survey_group ( survey_group -> group_order ) </title></a>
 
 <!-- ============= Table 'survey_group' ============= -->
-<rect class='table' x='90' y='1358' width='105' height='90' rx='7' ry='7' />
-<path d='M 90.50 1384.50 L 90.50 1365.50 Q 90.50 1358.50 97.50 1358.50 L 187.50 1358.50 Q 194.50 1358.50 194.50 1365.50 L 194.50 1384.50 L90.50 1384.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#survey_group'><text x='105' y='1372' class='tableTitle'>survey_group</text><title>Table ag.survey_group</title></a>
-  <use id='nn' x='92' y='1392' xlink:href='#nn'/><a xlink:href='#group_order'><use id='pk' x='92' y='1391' xlink:href='#pk'/><title>Primary Key  ( group_order ) </title></a>
-<a xlink:href='#group_order'><text x='108' y='1402'>group_order</text><title>group_order integer not null
+<rect class='table' x='45' y='1358' width='105' height='90' rx='7' ry='7' />
+<path d='M 45.50 1384.50 L 45.50 1365.50 Q 45.50 1358.50 52.50 1358.50 L 142.50 1358.50 Q 149.50 1358.50 149.50 1365.50 L 149.50 1384.50 L45.50 1384.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#survey_group'><text x='60' y='1372' class='tableTitle'>survey_group</text><title>Table ag.survey_group</title></a>
+  <use id='nn' x='47' y='1392' xlink:href='#nn'/><a xlink:href='#group_order'><use id='pk' x='47' y='1391' xlink:href='#pk'/><title>Primary Key  ( group_order ) </title></a>
+<a xlink:href='#group_order'><text x='63' y='1402'>group_order</text><title>group_order integer not null
 The order that this group will be displayed in</title></a>
-<a xlink:href='#group_order'><use id='ref' x='183' y='1391' xlink:href='#ref'/><title>Referred by group_questions ( survey_group -> group_order ) 
+<a xlink:href='#group_order'><use id='ref' x='138' y='1391' xlink:href='#ref'/><title>Referred by group_questions ( survey_group -> group_order ) 
 Referred by surveys ( survey_group -> group_order ) </title></a>
-  <a xlink:href='#american'><use id='unq' x='92' y='1406' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
-<a xlink:href='#american'><text x='108' y='1417'>american</text><title>american varchar
+  <a xlink:href='#american'><use id='unq' x='47' y='1406' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
+<a xlink:href='#american'><text x='63' y='1417'>american</text><title>american varchar
 The american english version of the question group&#039;s name</title></a>
-  <a xlink:href='#british'><use id='unq' x='92' y='1421' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
-<a xlink:href='#british'><text x='108' y='1432'>british</text><title>british varchar</title></a>
+  <a xlink:href='#british'><use id='unq' x='47' y='1421' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
+<a xlink:href='#british'><text x='63' y='1432'>british</text><title>british varchar</title></a>
 
 <!-- ============= Table 'ag_kit' ============= -->
-<rect class='table' x='1155' y='683' width='165' height='210' rx='7' ry='7' />
-<path d='M 1155.50 709.50 L 1155.50 690.50 Q 1155.50 683.50 1162.50 683.50 L 1312.50 683.50 Q 1319.50 683.50 1319.50 690.50 L 1319.50 709.50 L1155.50 709.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#ag_kit'><text x='1221' y='697' class='tableTitle'>ag_kit</text><title>Table ag.ag_kit</title></a>
-  <use id='nn' x='1157' y='717' xlink:href='#nn'/><a xlink:href='#ag_kit_id'><use id='pk' x='1157' y='716' xlink:href='#pk'/><title>Primary Key  ( ag_kit_id ) </title></a>
-<a xlink:href='#ag_kit_id'><text x='1173' y='727'>ag_kit_id</text><title>ag_kit_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
-<a xlink:href='#ag_kit_id'><use id='ref' x='1308' y='716' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( ag_kit_id ) </title></a>
-  <use id='nn' x='1157' y='732' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='idx' x='1157' y='731' xlink:href='#idx'/><title>Index  ( ag_login_id ) </title></a>
-<a xlink:href='#ag_login_id'><text x='1173' y='742'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
-<a xlink:href='#ag_login_id'><use id='fk' x='1308' y='731' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
-  <use id='nn' x='1157' y='747' xlink:href='#nn'/><a xlink:href='#supplied_kit_id'><use id='unq' x='1157' y='746' xlink:href='#unq'/><title>Unique Index  ( supplied_kit_id ) </title></a>
-<a xlink:href='#supplied_kit_id'><text x='1173' y='757'>supplied_kit_id</text><title>supplied_kit_id varchar&#040;50&#041; not null</title></a>
-  <a xlink:href='#kit_password'><text x='1173' y='772'>kit_password</text><title>kit_password varchar&#040;50&#041;</title></a>
-  <use id='nn' x='1157' y='777' xlink:href='#nn'/><a xlink:href='#swabs_per_kit'><text x='1173' y='787'>swabs_per_kit</text><title>swabs_per_kit bigint not null</title></a>
-  <a xlink:href='#kit_verification_code'><text x='1173' y='802'>kit_verification_code</text><title>kit_verification_code varchar&#040;50&#041;</title></a>
-  <a xlink:href='#kit_verified'><text x='1173' y='817'>kit_verified</text><title>kit_verified char&#040;1&#041; default &#039;n&#039;&#058;&#058;bpchar</title></a>
-  <a xlink:href='#verification_email_sent'><text x='1173' y='832'>verification_email_sent</text><title>verification_email_sent char&#040;1&#041; default &#039;n&#039;&#058;&#058;bpchar</title></a>
-  <a xlink:href='#pass_reset_code'><text x='1173' y='847'>pass_reset_code</text><title>pass_reset_code varchar&#040;20&#041;</title></a>
-  <a xlink:href='#pass_reset_time'><text x='1173' y='862'>pass_reset_time</text><title>pass_reset_time timestamp</title></a>
-  <a xlink:href='#print_results'><text x='1173' y='877'>print_results</text><title>print_results varchar&#040;1&#041; default &#039;n&#039;&#058;&#058;character varying</title></a>
+<rect class='table' x='1110' y='683' width='165' height='210' rx='7' ry='7' />
+<path d='M 1110.50 709.50 L 1110.50 690.50 Q 1110.50 683.50 1117.50 683.50 L 1267.50 683.50 Q 1274.50 683.50 1274.50 690.50 L 1274.50 709.50 L1110.50 709.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#ag_kit'><text x='1176' y='697' class='tableTitle'>ag_kit</text><title>Table ag.ag_kit</title></a>
+  <use id='nn' x='1112' y='717' xlink:href='#nn'/><a xlink:href='#ag_kit_id'><use id='pk' x='1112' y='716' xlink:href='#pk'/><title>Primary Key  ( ag_kit_id ) </title></a>
+<a xlink:href='#ag_kit_id'><text x='1128' y='727'>ag_kit_id</text><title>ag_kit_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
+<a xlink:href='#ag_kit_id'><use id='ref' x='1263' y='716' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( ag_kit_id ) </title></a>
+  <use id='nn' x='1112' y='732' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='idx' x='1112' y='731' xlink:href='#idx'/><title>Index  ( ag_login_id ) </title></a>
+<a xlink:href='#ag_login_id'><text x='1128' y='742'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
+<a xlink:href='#ag_login_id'><use id='fk' x='1263' y='731' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
+  <use id='nn' x='1112' y='747' xlink:href='#nn'/><a xlink:href='#supplied_kit_id'><use id='unq' x='1112' y='746' xlink:href='#unq'/><title>Unique Index  ( supplied_kit_id ) </title></a>
+<a xlink:href='#supplied_kit_id'><text x='1128' y='757'>supplied_kit_id</text><title>supplied_kit_id varchar&#040;50&#041; not null</title></a>
+  <a xlink:href='#kit_password'><text x='1128' y='772'>kit_password</text><title>kit_password varchar&#040;50&#041;</title></a>
+  <use id='nn' x='1112' y='777' xlink:href='#nn'/><a xlink:href='#swabs_per_kit'><text x='1128' y='787'>swabs_per_kit</text><title>swabs_per_kit bigint not null</title></a>
+  <a xlink:href='#kit_verification_code'><text x='1128' y='802'>kit_verification_code</text><title>kit_verification_code varchar&#040;50&#041;</title></a>
+  <a xlink:href='#kit_verified'><text x='1128' y='817'>kit_verified</text><title>kit_verified char&#040;1&#041; default &#039;n&#039;&#058;&#058;bpchar</title></a>
+  <a xlink:href='#verification_email_sent'><text x='1128' y='832'>verification_email_sent</text><title>verification_email_sent char&#040;1&#041; default &#039;n&#039;&#058;&#058;bpchar</title></a>
+  <a xlink:href='#pass_reset_code'><text x='1128' y='847'>pass_reset_code</text><title>pass_reset_code varchar&#040;20&#041;</title></a>
+  <a xlink:href='#pass_reset_time'><text x='1128' y='862'>pass_reset_time</text><title>pass_reset_time timestamp</title></a>
+  <a xlink:href='#print_results'><text x='1128' y='877'>print_results</text><title>print_results varchar&#040;1&#041; default &#039;n&#039;&#058;&#058;character varying</title></a>
 
 <!-- ============= Table 'survey_answers_other' ============= -->
-<rect class='table' x='1350' y='1133' width='135' height='90' rx='7' ry='7' />
-<path d='M 1350.50 1159.50 L 1350.50 1140.50 Q 1350.50 1133.50 1357.50 1133.50 L 1477.50 1133.50 Q 1484.50 1133.50 1484.50 1140.50 L 1484.50 1159.50 L1350.50 1159.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#survey_answers_other'><text x='1357' y='1147' class='tableTitle'>survey_answers_other</text><title>Table ag.survey_answers_other
+<rect class='table' x='1305' y='1133' width='135' height='90' rx='7' ry='7' />
+<path d='M 1305.50 1159.50 L 1305.50 1140.50 Q 1305.50 1133.50 1312.50 1133.50 L 1432.50 1133.50 Q 1439.50 1133.50 1439.50 1140.50 L 1439.50 1159.50 L1305.50 1159.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#survey_answers_other'><text x='1312' y='1147' class='tableTitle'>survey_answers_other</text><title>Table ag.survey_answers_other
 Survey answers for which there are no corresponding foreign keys</title></a>
-  <use id='nn' x='1352' y='1167' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1352' y='1166' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) Index  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1368' y='1177'>survey_id</text><title>survey_id varchar not null</title></a>
-<a xlink:href='#survey_id'><use id='fk' x='1473' y='1166' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
-  <use id='nn' x='1352' y='1182' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='1352' y='1181' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) Index  ( survey_question_id ) </title></a>
-<a xlink:href='#survey_question_id'><text x='1368' y='1192'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
-<a xlink:href='#survey_question_id'><use id='fk' x='1473' y='1181' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
-  <use id='nn' x='1352' y='1197' xlink:href='#nn'/><a xlink:href='#response'><text x='1368' y='1207'>response</text><title>response varchar not null</title></a>
+  <use id='nn' x='1307' y='1167' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1307' y='1166' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) Index  ( survey_id ) </title></a>
+<a xlink:href='#survey_id'><text x='1323' y='1177'>survey_id</text><title>survey_id varchar not null</title></a>
+<a xlink:href='#survey_id'><use id='fk' x='1428' y='1166' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
+  <use id='nn' x='1307' y='1182' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='1307' y='1181' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) Index  ( survey_question_id ) </title></a>
+<a xlink:href='#survey_question_id'><text x='1323' y='1192'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
+<a xlink:href='#survey_question_id'><use id='fk' x='1428' y='1181' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
+  <use id='nn' x='1307' y='1197' xlink:href='#nn'/><a xlink:href='#response'><text x='1323' y='1207'>response</text><title>response varchar not null</title></a>
 
 <!-- ============= Table 'survey_question_triggers' ============= -->
-<rect class='table' x='690' y='1418' width='150' height='90' rx='7' ry='7' />
-<path d='M 690.50 1444.50 L 690.50 1425.50 Q 690.50 1418.50 697.50 1418.50 L 832.50 1418.50 Q 839.50 1418.50 839.50 1425.50 L 839.50 1444.50 L690.50 1444.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#survey_question_triggers'><text x='696' y='1432' class='tableTitle'>survey_question_triggers</text><title>Table ag.survey_question_triggers
+<rect class='table' x='645' y='1418' width='150' height='90' rx='7' ry='7' />
+<path d='M 645.50 1444.50 L 645.50 1425.50 Q 645.50 1418.50 652.50 1418.50 L 787.50 1418.50 Q 794.50 1418.50 794.50 1425.50 L 794.50 1444.50 L645.50 1444.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#survey_question_triggers'><text x='651' y='1432' class='tableTitle'>survey_question_triggers</text><title>Table ag.survey_question_triggers
 Which question&#047;answer combos trigger other questions</title></a>
-  <a xlink:href='#survey_question_id'><use id='idx' x='692' y='1451' xlink:href='#idx'/><title>Index  ( survey_question_id ) Index  ( survey_question_id, triggering_response ) </title></a>
-<a xlink:href='#survey_question_id'><text x='708' y='1462'>survey_question_id</text><title>survey_question_id bigint
+  <a xlink:href='#survey_question_id'><use id='idx' x='647' y='1451' xlink:href='#idx'/><title>Index  ( survey_question_id ) Index  ( survey_question_id, triggering_response ) </title></a>
+<a xlink:href='#survey_question_id'><text x='663' y='1462'>survey_question_id</text><title>survey_question_id bigint
 The ID of the question that is triggered</title></a>
-<a xlink:href='#survey_question_id'><use id='fk' x='828' y='1451' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, triggering_response -> response ) </title></a>
-  <a xlink:href='#triggering_response'><use id='idx' x='692' y='1466' xlink:href='#idx'/><title>Index  ( triggering_response ) Index  ( triggered_question, triggering_response ) Index  ( survey_question_id, triggering_response ) </title></a>
-<a xlink:href='#triggering_response'><text x='708' y='1477'>triggering_response</text><title>triggering_response varchar
+<a xlink:href='#survey_question_id'><use id='fk' x='783' y='1451' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, triggering_response -> response ) </title></a>
+  <a xlink:href='#triggering_response'><use id='idx' x='647' y='1466' xlink:href='#idx'/><title>Index  ( triggering_response ) Index  ( triggered_question, triggering_response ) Index  ( survey_question_id, triggering_response ) </title></a>
+<a xlink:href='#triggering_response'><text x='663' y='1477'>triggering_response</text><title>triggering_response varchar
 The response to the question that will cause the appearance of the triggered&#095;question</title></a>
-<a xlink:href='#triggering_response'><use id='fk' x='828' y='1466' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, triggering_response -> response ) </title></a>
-  <a xlink:href='#triggered_question'><use id='idx' x='692' y='1481' xlink:href='#idx'/><title>Index  ( triggered_question ) Index  ( triggered_question, triggering_response ) </title></a>
-<a xlink:href='#triggered_question'><text x='708' y='1492'>triggered_question</text><title>triggered_question bigint
+<a xlink:href='#triggering_response'><use id='fk' x='783' y='1466' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, triggering_response -> response ) </title></a>
+  <a xlink:href='#triggered_question'><use id='idx' x='647' y='1481' xlink:href='#idx'/><title>Index  ( triggered_question ) Index  ( triggered_question, triggering_response ) </title></a>
+<a xlink:href='#triggered_question'><text x='663' y='1492'>triggered_question</text><title>triggered_question bigint
 The question that is triggered</title></a>
-<a xlink:href='#triggered_question'><use id='fk' x='828' y='1481' xlink:href='#fk'/><title>References survey_question ( triggered_question -> survey_question_id ) </title></a>
+<a xlink:href='#triggered_question'><use id='fk' x='783' y='1481' xlink:href='#fk'/><title>References survey_question ( triggered_question -> survey_question_id ) </title></a>
 
 <!-- ============= Table 'survey_response' ============= -->
-<rect class='table' x='735' y='1628' width='105' height='75' rx='7' ry='7' />
-<path d='M 735.50 1654.50 L 735.50 1635.50 Q 735.50 1628.50 742.50 1628.50 L 832.50 1628.50 Q 839.50 1628.50 839.50 1635.50 L 839.50 1654.50 L735.50 1654.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#survey_response'><text x='741' y='1642' class='tableTitle'>survey_response</text><title>Table ag.survey_response
+<rect class='table' x='690' y='1628' width='105' height='75' rx='7' ry='7' />
+<path d='M 690.50 1654.50 L 690.50 1635.50 Q 690.50 1628.50 697.50 1628.50 L 787.50 1628.50 Q 794.50 1628.50 794.50 1635.50 L 794.50 1654.50 L690.50 1654.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#survey_response'><text x='696' y='1642' class='tableTitle'>survey_response</text><title>Table ag.survey_response
 Stores every possible predictable response on the human survey</title></a>
-  <use id='nn' x='737' y='1662' xlink:href='#nn'/><a xlink:href='#american'><use id='pk' x='737' y='1661' xlink:href='#pk'/><title>Primary Key  ( american ) </title></a>
-<a xlink:href='#american'><text x='753' y='1672'>american</text><title>american varchar not null</title></a>
-<a xlink:href='#american'><use id='ref' x='828' y='1661' xlink:href='#ref'/><title>Referred by iso_country_lookup ( country -> american ) 
+  <use id='nn' x='692' y='1662' xlink:href='#nn'/><a xlink:href='#american'><use id='pk' x='692' y='1661' xlink:href='#pk'/><title>Primary Key  ( american ) </title></a>
+<a xlink:href='#american'><text x='708' y='1672'>american</text><title>american varchar not null</title></a>
+<a xlink:href='#american'><use id='ref' x='783' y='1661' xlink:href='#ref'/><title>Referred by iso_country_lookup ( country -> american ) 
 Referred by survey_question_response ( response -> american ) </title></a>
-  <a xlink:href='#british'><use id='unq' x='737' y='1676' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
-<a xlink:href='#british'><text x='753' y='1687'>british</text><title>british varchar</title></a>
+  <a xlink:href='#british'><use id='unq' x='692' y='1676' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
+<a xlink:href='#british'><text x='708' y='1687'>british</text><title>british varchar</title></a>
 
 <!-- ============= Table 'survey_question_response' ============= -->
-<rect class='table' x='735' y='1523' width='165' height='90' rx='7' ry='7' />
-<path d='M 735.50 1549.50 L 735.50 1530.50 Q 735.50 1523.50 742.50 1523.50 L 892.50 1523.50 Q 899.50 1523.50 899.50 1530.50 L 899.50 1549.50 L735.50 1549.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
-<a xlink:href='#survey_question_response'><text x='745' y='1537' class='tableTitle'>survey_question_response</text><title>Table ag.survey_question_response
+<rect class='table' x='690' y='1523' width='165' height='90' rx='7' ry='7' />
+<path d='M 690.50 1549.50 L 690.50 1530.50 Q 690.50 1523.50 697.50 1523.50 L 847.50 1523.50 Q 854.50 1523.50 854.50 1530.50 L 854.50 1549.50 L690.50 1549.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#survey_question_response'><text x='700' y='1537' class='tableTitle'>survey_question_response</text><title>Table ag.survey_question_response
 Maps questions to responses</title></a>
-  <use id='nn' x='737' y='1557' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='737' y='1556' xlink:href='#pk'/><title>Primary Key  ( survey_question_id, response ) Unique Index  ( survey_question_id, display_index ) </title></a>
-<a xlink:href='#survey_question_id'><text x='753' y='1567'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
-<a xlink:href='#survey_question_id'><use id='fk' x='888' y='1556' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) 
+  <use id='nn' x='692' y='1557' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='692' y='1556' xlink:href='#pk'/><title>Primary Key  ( survey_question_id, response ) Unique Index  ( survey_question_id, display_index ) </title></a>
+<a xlink:href='#survey_question_id'><text x='708' y='1567'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
+<a xlink:href='#survey_question_id'><use id='fk' x='843' y='1556' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) 
 Referred by survey_answers ( survey_question_id, response ) 
 Referred by survey_question_triggers ( survey_question_id, triggering_response -> response ) </title></a>
-  <use id='nn' x='737' y='1572' xlink:href='#nn'/><a xlink:href='#response'><use id='pk' x='737' y='1571' xlink:href='#pk'/><title>Primary Key  ( survey_question_id, response ) </title></a>
-<a xlink:href='#response'><text x='753' y='1582'>response</text><title>response varchar not null</title></a>
-<a xlink:href='#response'><use id='fk' x='888' y='1571' xlink:href='#fk'/><title>References survey_response ( response -> american ) 
+  <use id='nn' x='692' y='1572' xlink:href='#nn'/><a xlink:href='#response'><use id='pk' x='692' y='1571' xlink:href='#pk'/><title>Primary Key  ( survey_question_id, response ) </title></a>
+<a xlink:href='#response'><text x='708' y='1582'>response</text><title>response varchar not null</title></a>
+<a xlink:href='#response'><use id='fk' x='843' y='1571' xlink:href='#fk'/><title>References survey_response ( response -> american ) 
 Referred by survey_answers ( survey_question_id, response ) 
 Referred by survey_question_triggers ( survey_question_id, triggering_response -> response ) </title></a>
-  <a xlink:href='#display_index'><use id='unq' x='737' y='1586' xlink:href='#unq'/><title>Unique Index  ( survey_question_id, display_index ) </title></a>
-<a xlink:href='#display_index'><text x='753' y='1597'>display_index</text><title>display_index serial
+  <a xlink:href='#display_index'><use id='unq' x='692' y='1586' xlink:href='#unq'/><title>Unique Index  ( survey_question_id, display_index ) </title></a>
+<a xlink:href='#display_index'><text x='708' y='1597'>display_index</text><title>display_index serial
 The display order of this response</title></a>
 
 <!-- ============= Table 'ag_human_survey' ============= -->
-<rect class='table' x='1710' y='413' width='180' height='1710' rx='7' ry='7' />
-<path d='M 1710.50 439.50 L 1710.50 420.50 Q 1710.50 413.50 1717.50 413.50 L 1882.50 413.50 Q 1889.50 413.50 1889.50 420.50 L 1889.50 439.50 L1710.50 439.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
-<a xlink:href='#ag_human_survey'><text x='1751' y='427' class='tableTitle'>ag_human_survey</text><title>Table ag.ag_human_survey</title></a>
-  <use id='nn' x='1712' y='447' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='1712' y='446' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
-<a xlink:href='#ag_login_id'><text x='1728' y='457'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
-<a xlink:href='#ag_login_id'><use id='fk' x='1878' y='446' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
-  <use id='nn' x='1712' y='462' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='1712' y='461' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
-<a xlink:href='#participant_name'><text x='1728' y='472'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
-  <a xlink:href='#consent'><text x='1728' y='487'>consent</text><title>consent varchar&#040;20&#041;</title></a>
-  <a xlink:href='#juvenile_age'><text x='1728' y='502'>juvenile_age</text><title>juvenile_age varchar&#040;20&#041;</title></a>
-  <a xlink:href='#parent_1_name'><text x='1728' y='517'>parent_1_name</text><title>parent_1_name varchar&#040;200&#041;</title></a>
-  <a xlink:href='#parent_2_name'><text x='1728' y='532'>parent_2_name</text><title>parent_2_name varchar&#040;200&#041;</title></a>
-  <a xlink:href='#deceased_parent'><text x='1728' y='547'>deceased_parent</text><title>deceased_parent varchar&#040;20&#041;</title></a>
-  <a xlink:href='#country_of_birth'><text x='1728' y='562'>country_of_birth</text><title>country_of_birth varchar&#040;100&#041;</title></a>
-  <a xlink:href='#birth_date'><text x='1728' y='577'>birth_date</text><title>birth_date varchar&#040;100&#041;</title></a>
-  <a xlink:href='#gender'><text x='1728' y='592'>gender</text><title>gender varchar&#040;100&#041;</title></a>
-  <a xlink:href='#height_in'><text x='1728' y='607'>height_in</text><title>height_in varchar&#040;100&#041;</title></a>
-  <a xlink:href='#height_cm'><text x='1728' y='622'>height_cm</text><title>height_cm varchar&#040;100&#041;</title></a>
-  <a xlink:href='#weight_lbs'><text x='1728' y='637'>weight_lbs</text><title>weight_lbs varchar&#040;100&#041;</title></a>
-  <a xlink:href='#weight_kg'><text x='1728' y='652'>weight_kg</text><title>weight_kg varchar&#040;100&#041;</title></a>
-  <a xlink:href='#phone_num'><text x='1728' y='667'>phone_num</text><title>phone_num varchar&#040;100&#041;</title></a>
-  <a xlink:href='#zip_code'><text x='1728' y='682'>zip_code</text><title>zip_code varchar&#040;100&#041;</title></a>
-  <a xlink:href='#diet_type'><text x='1728' y='697'>diet_type</text><title>diet_type varchar&#040;100&#041;</title></a>
-  <a xlink:href='#multivitamin'><text x='1728' y='712'>multivitamin</text><title>multivitamin varchar&#040;100&#041;</title></a>
-  <a xlink:href='#supplements'><text x='1728' y='727'>supplements</text><title>supplements varchar&#040;100&#041;</title></a>
-  <a xlink:href='#lactose'><text x='1728' y='742'>lactose</text><title>lactose varchar&#040;100&#041;</title></a>
-  <a xlink:href='#gluten'><text x='1728' y='757'>gluten</text><title>gluten varchar&#040;100&#041;</title></a>
-  <a xlink:href='#foodallergies_peanuts'><text x='1728' y='772'>foodallergies_peanuts</text><title>foodallergies_peanuts varchar&#040;100&#041;</title></a>
-  <a xlink:href='#foodallergies_treenuts'><text x='1728' y='787'>foodallergies_treenuts</text><title>foodallergies_treenuts varchar&#040;100&#041;</title></a>
-  <a xlink:href='#foodallergies_shellfish'><text x='1728' y='802'>foodallergies_shellfish</text><title>foodallergies_shellfish varchar&#040;100&#041;</title></a>
-  <a xlink:href='#foodallergies_other'><text x='1728' y='817'>foodallergies_other</text><title>foodallergies_other varchar&#040;100&#041;</title></a>
-  <a xlink:href='#foodallergies_other_text'><text x='1728' y='832'>foodallergies_other_text</text><title>foodallergies_other_text varchar&#040;400&#041;</title></a>
-  <a xlink:href='#special_restrictions'><text x='1728' y='847'>special_restrictions</text><title>special_restrictions varchar&#040;100&#041;</title></a>
-  <a xlink:href='#drinking_water_source'><text x='1728' y='862'>drinking_water_source</text><title>drinking_water_source varchar&#040;100&#041;</title></a>
-  <a xlink:href='#race'><text x='1728' y='877'>race</text><title>race varchar&#040;100&#041;</title></a>
-  <a xlink:href='#race_other'><text x='1728' y='892'>race_other</text><title>race_other varchar&#040;100&#041;</title></a>
-  <a xlink:href='#current_residence_duration'><text x='1728' y='907'>current_residence_duration</text><title>current_residence_duration varchar&#040;100&#041;</title></a>
-  <a xlink:href='#last_travel'><text x='1728' y='922'>last_travel</text><title>last_travel varchar&#040;100&#041;</title></a>
-  <a xlink:href='#livingwith'><text x='1728' y='937'>livingwith</text><title>livingwith varchar&#040;100&#041;</title></a>
-  <a xlink:href='#dog'><text x='1728' y='952'>dog</text><title>dog varchar&#040;100&#041;</title></a>
-  <a xlink:href='#cat'><text x='1728' y='967'>cat</text><title>cat varchar&#040;100&#041;</title></a>
-  <a xlink:href='#hand'><text x='1728' y='982'>hand</text><title>hand varchar&#040;100&#041;</title></a>
-  <a xlink:href='#shared_housing'><text x='1728' y='997'>shared_housing</text><title>shared_housing varchar&#040;100&#041;</title></a>
-  <a xlink:href='#tanning_beds'><text x='1728' y='1012'>tanning_beds</text><title>tanning_beds varchar&#040;100&#041;</title></a>
-  <a xlink:href='#tanning_sprays'><text x='1728' y='1027'>tanning_sprays</text><title>tanning_sprays varchar&#040;100&#041;</title></a>
-  <a xlink:href='#exercise_frequency'><text x='1728' y='1042'>exercise_frequency</text><title>exercise_frequency varchar&#040;100&#041;</title></a>
-  <a xlink:href='#exercise_location'><text x='1728' y='1057'>exercise_location</text><title>exercise_location varchar&#040;100&#041;</title></a>
-  <a xlink:href='#nails'><text x='1728' y='1072'>nails</text><title>nails varchar&#040;100&#041;</title></a>
-  <a xlink:href='#pool_frequency'><text x='1728' y='1087'>pool_frequency</text><title>pool_frequency varchar&#040;100&#041;</title></a>
-  <a xlink:href='#smoking_frequency'><text x='1728' y='1102'>smoking_frequency</text><title>smoking_frequency varchar&#040;100&#041;</title></a>
-  <a xlink:href='#alcohol_frequency'><text x='1728' y='1117'>alcohol_frequency</text><title>alcohol_frequency varchar&#040;100&#041;</title></a>
-  <a xlink:href='#teethbrushing_frequency'><text x='1728' y='1132'>teethbrushing_frequency</text><title>teethbrushing_frequency varchar&#040;100&#041;</title></a>
-  <a xlink:href='#flossing_frequency'><text x='1728' y='1147'>flossing_frequency</text><title>flossing_frequency varchar&#040;100&#041;</title></a>
-  <a xlink:href='#cosmetics_frequency'><text x='1728' y='1162'>cosmetics_frequency</text><title>cosmetics_frequency varchar&#040;100&#041;</title></a>
-  <a xlink:href='#deoderant_use'><text x='1728' y='1177'>deoderant_use</text><title>deoderant_use varchar&#040;100&#041;</title></a>
-  <a xlink:href='#sleep_duration'><text x='1728' y='1192'>sleep_duration</text><title>sleep_duration varchar&#040;100&#041;</title></a>
-  <a xlink:href='#softener'><text x='1728' y='1207'>softener</text><title>softener varchar&#040;100&#041;</title></a>
-  <a xlink:href='#antibiotic_select'><text x='1728' y='1222'>antibiotic_select</text><title>antibiotic_select varchar&#040;100&#041;</title></a>
-  <a xlink:href='#antibiotic_condition'><text x='1728' y='1237'>antibiotic_condition</text><title>antibiotic_condition varchar&#040;100&#041;</title></a>
-  <a xlink:href='#flu_vaccine_date'><text x='1728' y='1252'>flu_vaccine_date</text><title>flu_vaccine_date varchar&#040;100&#041;</title></a>
-  <a xlink:href='#weight_change'><text x='1728' y='1267'>weight_change</text><title>weight_change varchar&#040;100&#041;</title></a>
-  <a xlink:href='#tonsils_removed'><text x='1728' y='1282'>tonsils_removed</text><title>tonsils_removed varchar&#040;100&#041;</title></a>
-  <a xlink:href='#appendix_removed'><text x='1728' y='1297'>appendix_removed</text><title>appendix_removed varchar&#040;100&#041;</title></a>
-  <a xlink:href='#chickenpox'><text x='1728' y='1312'>chickenpox</text><title>chickenpox varchar&#040;100&#041;</title></a>
-  <a xlink:href='#acne_medication'><text x='1728' y='1327'>acne_medication</text><title>acne_medication varchar&#040;100&#041;</title></a>
-  <a xlink:href='#acne_medication_otc'><text x='1728' y='1342'>acne_medication_otc</text><title>acne_medication_otc varchar&#040;100&#041;</title></a>
-  <a xlink:href='#conditions_medication'><text x='1728' y='1357'>conditions_medication</text><title>conditions_medication varchar&#040;100&#041;</title></a>
-  <a xlink:href='#csection'><text x='1728' y='1372'>csection</text><title>csection varchar&#040;100&#041;</title></a>
-  <a xlink:href='#pku'><text x='1728' y='1387'>pku</text><title>pku varchar&#040;100&#041;</title></a>
-  <a xlink:href='#asthma'><text x='1728' y='1402'>asthma</text><title>asthma varchar&#040;100&#041;</title></a>
-  <a xlink:href='#seasonal_allergies'><text x='1728' y='1417'>seasonal_allergies</text><title>seasonal_allergies varchar&#040;100&#041;</title></a>
-  <a xlink:href='#nonfoodallergies_drug'><text x='1728' y='1432'>nonfoodallergies_drug</text><title>nonfoodallergies_drug varchar&#040;100&#041;</title></a>
-  <a xlink:href='#nonfoodallergies_dander'><text x='1728' y='1447'>nonfoodallergies_dander</text><title>nonfoodallergies_dander varchar&#040;100&#041;</title></a>
-  <a xlink:href='#nonfoodallergies_beestings'><text x='1728' y='1462'>nonfoodallergies_beestings</text><title>nonfoodallergies_beestings varchar&#040;100&#041;</title></a>
-  <a xlink:href='#nonfoodallergies_poisonivy'><text x='1728' y='1477'>nonfoodallergies_poisonivy</text><title>nonfoodallergies_poisonivy varchar&#040;100&#041;</title></a>
-  <a xlink:href='#nonfoodallergies_sun'><text x='1728' y='1492'>nonfoodallergies_sun</text><title>nonfoodallergies_sun varchar&#040;100&#041;</title></a>
-  <a xlink:href='#nonfoodallergies_no'><text x='1728' y='1507'>nonfoodallergies_no</text><title>nonfoodallergies_no varchar&#040;100&#041;</title></a>
-  <a xlink:href='#ibd'><text x='1728' y='1522'>ibd</text><title>ibd varchar&#040;100&#041;</title></a>
-  <a xlink:href='#skin_condition'><text x='1728' y='1537'>skin_condition</text><title>skin_condition varchar&#040;100&#041;</title></a>
-  <a xlink:href='#diabetes'><text x='1728' y='1552'>diabetes</text><title>diabetes varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine'><text x='1728' y='1567'>migraine</text><title>migraine varchar&#040;100&#041;</title></a>
-  <a xlink:href='#protein_per'><text x='1728' y='1582'>protein_per</text><title>protein_per varchar&#040;100&#041;</title></a>
-  <a xlink:href='#fat_per'><text x='1728' y='1597'>fat_per</text><title>fat_per varchar&#040;100&#041;</title></a>
-  <a xlink:href='#carbohydrate_per'><text x='1728' y='1612'>carbohydrate_per</text><title>carbohydrate_per varchar&#040;100&#041;</title></a>
-  <a xlink:href='#plant_per'><text x='1728' y='1627'>plant_per</text><title>plant_per varchar&#040;100&#041;</title></a>
-  <a xlink:href='#animal_per'><text x='1728' y='1642'>animal_per</text><title>animal_per varchar&#040;100&#041;</title></a>
-  <a xlink:href='#fiber_grams'><text x='1728' y='1657'>fiber_grams</text><title>fiber_grams varchar&#040;100&#041;</title></a>
-  <a xlink:href='#types_of_plants'><text x='1728' y='1672'>types_of_plants</text><title>types_of_plants varchar&#040;100&#041;</title></a>
-  <a xlink:href='#percentage_from_carbs'><text x='1728' y='1687'>percentage_from_carbs</text><title>percentage_from_carbs varchar&#040;100&#041;</title></a>
-  <a xlink:href='#primary_vegetable'><text x='1728' y='1702'>primary_vegetable</text><title>primary_vegetable varchar&#040;100&#041;</title></a>
-  <a xlink:href='#primary_carb'><text x='1728' y='1717'>primary_carb</text><title>primary_carb varchar&#040;100&#041;</title></a>
-  <a xlink:href='#diabetes_diagnose_date'><text x='1728' y='1732'>diabetes_diagnose_date</text><title>diabetes_diagnose_date varchar&#040;100&#041;</title></a>
-  <a xlink:href='#diabetes_medication'><text x='1728' y='1747'>diabetes_medication</text><title>diabetes_medication varchar&#040;100&#041;</title></a>
-  <a xlink:href='#contraceptive'><text x='1728' y='1762'>contraceptive</text><title>contraceptive varchar&#040;100&#041;</title></a>
-  <a xlink:href='#pregnant'><text x='1728' y='1777'>pregnant</text><title>pregnant varchar&#040;100&#041;</title></a>
-  <a xlink:href='#pregnant_due_date'><text x='1728' y='1792'>pregnant_due_date</text><title>pregnant_due_date varchar&#040;100&#041;</title></a>
-  <a xlink:href='#frat'><text x='1728' y='1807'>frat</text><title>frat varchar&#040;100&#041;</title></a>
-  <a xlink:href='#communal_dining'><text x='1728' y='1822'>communal_dining</text><title>communal_dining varchar&#040;100&#041;</title></a>
-  <a xlink:href='#roommates'><text x='1728' y='1837'>roommates</text><title>roommates varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_frequency'><text x='1728' y='1852'>migraine_frequency</text><title>migraine_frequency varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_factor_1'><text x='1728' y='1867'>migraine_factor_1</text><title>migraine_factor_1 varchar&#040;100&#041;</title></a>
-  <a xlink:href='#mainfactor_other_1'><text x='1728' y='1882'>mainfactor_other_1</text><title>mainfactor_other_1 varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_factor_2'><text x='1728' y='1897'>migraine_factor_2</text><title>migraine_factor_2 varchar&#040;100&#041;</title></a>
-  <a xlink:href='#mainfactor_other_2'><text x='1728' y='1912'>mainfactor_other_2</text><title>mainfactor_other_2 varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_factor_3'><text x='1728' y='1927'>migraine_factor_3</text><title>migraine_factor_3 varchar&#040;100&#041;</title></a>
-  <a xlink:href='#mainfactor_other_3'><text x='1728' y='1942'>mainfactor_other_3</text><title>mainfactor_other_3 varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_pain'><text x='1728' y='1957'>migraine_pain</text><title>migraine_pain varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_photophobia'><text x='1728' y='1972'>migraine_photophobia</text><title>migraine_photophobia varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_phonophobia'><text x='1728' y='1987'>migraine_phonophobia</text><title>migraine_phonophobia varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_nausea'><text x='1728' y='2002'>migraine_nausea</text><title>migraine_nausea varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_aggravation'><text x='1728' y='2017'>migraine_aggravation</text><title>migraine_aggravation varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_aura'><text x='1728' y='2032'>migraine_aura</text><title>migraine_aura varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migraine_relatives'><text x='1728' y='2047'>migraine_relatives</text><title>migraine_relatives varchar&#040;100&#041;</title></a>
-  <a xlink:href='#migrainemeds'><text x='1728' y='2062'>migrainemeds</text><title>migrainemeds varchar&#040;100&#041;</title></a>
-  <a xlink:href='#about_yourself_text'><text x='1728' y='2077'>about_yourself_text</text><title>about_yourself_text varchar&#040;2000&#041;</title></a>
-  <a xlink:href='#participant_email'><text x='1728' y='2092'>participant_email</text><title>participant_email varchar&#040;300&#041;</title></a>
-  <a xlink:href='#participant_name_u'><text x='1728' y='2107'>participant_name_u</text><title>participant_name_u varchar&#040;400&#041;</title></a>
+<rect class='table' x='1665' y='413' width='180' height='1710' rx='7' ry='7' />
+<path d='M 1665.50 439.50 L 1665.50 420.50 Q 1665.50 413.50 1672.50 413.50 L 1837.50 413.50 Q 1844.50 413.50 1844.50 420.50 L 1844.50 439.50 L1665.50 439.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
+<a xlink:href='#ag_human_survey'><text x='1706' y='427' class='tableTitle'>ag_human_survey</text><title>Table ag.ag_human_survey</title></a>
+  <use id='nn' x='1667' y='447' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='1667' y='446' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
+<a xlink:href='#ag_login_id'><text x='1683' y='457'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
+<a xlink:href='#ag_login_id'><use id='fk' x='1833' y='446' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
+  <use id='nn' x='1667' y='462' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='1667' y='461' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
+<a xlink:href='#participant_name'><text x='1683' y='472'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
+  <a xlink:href='#consent'><text x='1683' y='487'>consent</text><title>consent varchar&#040;20&#041;</title></a>
+  <a xlink:href='#juvenile_age'><text x='1683' y='502'>juvenile_age</text><title>juvenile_age varchar&#040;20&#041;</title></a>
+  <a xlink:href='#parent_1_name'><text x='1683' y='517'>parent_1_name</text><title>parent_1_name varchar&#040;200&#041;</title></a>
+  <a xlink:href='#parent_2_name'><text x='1683' y='532'>parent_2_name</text><title>parent_2_name varchar&#040;200&#041;</title></a>
+  <a xlink:href='#deceased_parent'><text x='1683' y='547'>deceased_parent</text><title>deceased_parent varchar&#040;20&#041;</title></a>
+  <a xlink:href='#country_of_birth'><text x='1683' y='562'>country_of_birth</text><title>country_of_birth varchar&#040;100&#041;</title></a>
+  <a xlink:href='#birth_date'><text x='1683' y='577'>birth_date</text><title>birth_date varchar&#040;100&#041;</title></a>
+  <a xlink:href='#gender'><text x='1683' y='592'>gender</text><title>gender varchar&#040;100&#041;</title></a>
+  <a xlink:href='#height_in'><text x='1683' y='607'>height_in</text><title>height_in varchar&#040;100&#041;</title></a>
+  <a xlink:href='#height_cm'><text x='1683' y='622'>height_cm</text><title>height_cm varchar&#040;100&#041;</title></a>
+  <a xlink:href='#weight_lbs'><text x='1683' y='637'>weight_lbs</text><title>weight_lbs varchar&#040;100&#041;</title></a>
+  <a xlink:href='#weight_kg'><text x='1683' y='652'>weight_kg</text><title>weight_kg varchar&#040;100&#041;</title></a>
+  <a xlink:href='#phone_num'><text x='1683' y='667'>phone_num</text><title>phone_num varchar&#040;100&#041;</title></a>
+  <a xlink:href='#zip_code'><text x='1683' y='682'>zip_code</text><title>zip_code varchar&#040;100&#041;</title></a>
+  <a xlink:href='#diet_type'><text x='1683' y='697'>diet_type</text><title>diet_type varchar&#040;100&#041;</title></a>
+  <a xlink:href='#multivitamin'><text x='1683' y='712'>multivitamin</text><title>multivitamin varchar&#040;100&#041;</title></a>
+  <a xlink:href='#supplements'><text x='1683' y='727'>supplements</text><title>supplements varchar&#040;100&#041;</title></a>
+  <a xlink:href='#lactose'><text x='1683' y='742'>lactose</text><title>lactose varchar&#040;100&#041;</title></a>
+  <a xlink:href='#gluten'><text x='1683' y='757'>gluten</text><title>gluten varchar&#040;100&#041;</title></a>
+  <a xlink:href='#foodallergies_peanuts'><text x='1683' y='772'>foodallergies_peanuts</text><title>foodallergies_peanuts varchar&#040;100&#041;</title></a>
+  <a xlink:href='#foodallergies_treenuts'><text x='1683' y='787'>foodallergies_treenuts</text><title>foodallergies_treenuts varchar&#040;100&#041;</title></a>
+  <a xlink:href='#foodallergies_shellfish'><text x='1683' y='802'>foodallergies_shellfish</text><title>foodallergies_shellfish varchar&#040;100&#041;</title></a>
+  <a xlink:href='#foodallergies_other'><text x='1683' y='817'>foodallergies_other</text><title>foodallergies_other varchar&#040;100&#041;</title></a>
+  <a xlink:href='#foodallergies_other_text'><text x='1683' y='832'>foodallergies_other_text</text><title>foodallergies_other_text varchar&#040;400&#041;</title></a>
+  <a xlink:href='#special_restrictions'><text x='1683' y='847'>special_restrictions</text><title>special_restrictions varchar&#040;100&#041;</title></a>
+  <a xlink:href='#drinking_water_source'><text x='1683' y='862'>drinking_water_source</text><title>drinking_water_source varchar&#040;100&#041;</title></a>
+  <a xlink:href='#race'><text x='1683' y='877'>race</text><title>race varchar&#040;100&#041;</title></a>
+  <a xlink:href='#race_other'><text x='1683' y='892'>race_other</text><title>race_other varchar&#040;100&#041;</title></a>
+  <a xlink:href='#current_residence_duration'><text x='1683' y='907'>current_residence_duration</text><title>current_residence_duration varchar&#040;100&#041;</title></a>
+  <a xlink:href='#last_travel'><text x='1683' y='922'>last_travel</text><title>last_travel varchar&#040;100&#041;</title></a>
+  <a xlink:href='#livingwith'><text x='1683' y='937'>livingwith</text><title>livingwith varchar&#040;100&#041;</title></a>
+  <a xlink:href='#dog'><text x='1683' y='952'>dog</text><title>dog varchar&#040;100&#041;</title></a>
+  <a xlink:href='#cat'><text x='1683' y='967'>cat</text><title>cat varchar&#040;100&#041;</title></a>
+  <a xlink:href='#hand'><text x='1683' y='982'>hand</text><title>hand varchar&#040;100&#041;</title></a>
+  <a xlink:href='#shared_housing'><text x='1683' y='997'>shared_housing</text><title>shared_housing varchar&#040;100&#041;</title></a>
+  <a xlink:href='#tanning_beds'><text x='1683' y='1012'>tanning_beds</text><title>tanning_beds varchar&#040;100&#041;</title></a>
+  <a xlink:href='#tanning_sprays'><text x='1683' y='1027'>tanning_sprays</text><title>tanning_sprays varchar&#040;100&#041;</title></a>
+  <a xlink:href='#exercise_frequency'><text x='1683' y='1042'>exercise_frequency</text><title>exercise_frequency varchar&#040;100&#041;</title></a>
+  <a xlink:href='#exercise_location'><text x='1683' y='1057'>exercise_location</text><title>exercise_location varchar&#040;100&#041;</title></a>
+  <a xlink:href='#nails'><text x='1683' y='1072'>nails</text><title>nails varchar&#040;100&#041;</title></a>
+  <a xlink:href='#pool_frequency'><text x='1683' y='1087'>pool_frequency</text><title>pool_frequency varchar&#040;100&#041;</title></a>
+  <a xlink:href='#smoking_frequency'><text x='1683' y='1102'>smoking_frequency</text><title>smoking_frequency varchar&#040;100&#041;</title></a>
+  <a xlink:href='#alcohol_frequency'><text x='1683' y='1117'>alcohol_frequency</text><title>alcohol_frequency varchar&#040;100&#041;</title></a>
+  <a xlink:href='#teethbrushing_frequency'><text x='1683' y='1132'>teethbrushing_frequency</text><title>teethbrushing_frequency varchar&#040;100&#041;</title></a>
+  <a xlink:href='#flossing_frequency'><text x='1683' y='1147'>flossing_frequency</text><title>flossing_frequency varchar&#040;100&#041;</title></a>
+  <a xlink:href='#cosmetics_frequency'><text x='1683' y='1162'>cosmetics_frequency</text><title>cosmetics_frequency varchar&#040;100&#041;</title></a>
+  <a xlink:href='#deoderant_use'><text x='1683' y='1177'>deoderant_use</text><title>deoderant_use varchar&#040;100&#041;</title></a>
+  <a xlink:href='#sleep_duration'><text x='1683' y='1192'>sleep_duration</text><title>sleep_duration varchar&#040;100&#041;</title></a>
+  <a xlink:href='#softener'><text x='1683' y='1207'>softener</text><title>softener varchar&#040;100&#041;</title></a>
+  <a xlink:href='#antibiotic_select'><text x='1683' y='1222'>antibiotic_select</text><title>antibiotic_select varchar&#040;100&#041;</title></a>
+  <a xlink:href='#antibiotic_condition'><text x='1683' y='1237'>antibiotic_condition</text><title>antibiotic_condition varchar&#040;100&#041;</title></a>
+  <a xlink:href='#flu_vaccine_date'><text x='1683' y='1252'>flu_vaccine_date</text><title>flu_vaccine_date varchar&#040;100&#041;</title></a>
+  <a xlink:href='#weight_change'><text x='1683' y='1267'>weight_change</text><title>weight_change varchar&#040;100&#041;</title></a>
+  <a xlink:href='#tonsils_removed'><text x='1683' y='1282'>tonsils_removed</text><title>tonsils_removed varchar&#040;100&#041;</title></a>
+  <a xlink:href='#appendix_removed'><text x='1683' y='1297'>appendix_removed</text><title>appendix_removed varchar&#040;100&#041;</title></a>
+  <a xlink:href='#chickenpox'><text x='1683' y='1312'>chickenpox</text><title>chickenpox varchar&#040;100&#041;</title></a>
+  <a xlink:href='#acne_medication'><text x='1683' y='1327'>acne_medication</text><title>acne_medication varchar&#040;100&#041;</title></a>
+  <a xlink:href='#acne_medication_otc'><text x='1683' y='1342'>acne_medication_otc</text><title>acne_medication_otc varchar&#040;100&#041;</title></a>
+  <a xlink:href='#conditions_medication'><text x='1683' y='1357'>conditions_medication</text><title>conditions_medication varchar&#040;100&#041;</title></a>
+  <a xlink:href='#csection'><text x='1683' y='1372'>csection</text><title>csection varchar&#040;100&#041;</title></a>
+  <a xlink:href='#pku'><text x='1683' y='1387'>pku</text><title>pku varchar&#040;100&#041;</title></a>
+  <a xlink:href='#asthma'><text x='1683' y='1402'>asthma</text><title>asthma varchar&#040;100&#041;</title></a>
+  <a xlink:href='#seasonal_allergies'><text x='1683' y='1417'>seasonal_allergies</text><title>seasonal_allergies varchar&#040;100&#041;</title></a>
+  <a xlink:href='#nonfoodallergies_drug'><text x='1683' y='1432'>nonfoodallergies_drug</text><title>nonfoodallergies_drug varchar&#040;100&#041;</title></a>
+  <a xlink:href='#nonfoodallergies_dander'><text x='1683' y='1447'>nonfoodallergies_dander</text><title>nonfoodallergies_dander varchar&#040;100&#041;</title></a>
+  <a xlink:href='#nonfoodallergies_beestings'><text x='1683' y='1462'>nonfoodallergies_beestings</text><title>nonfoodallergies_beestings varchar&#040;100&#041;</title></a>
+  <a xlink:href='#nonfoodallergies_poisonivy'><text x='1683' y='1477'>nonfoodallergies_poisonivy</text><title>nonfoodallergies_poisonivy varchar&#040;100&#041;</title></a>
+  <a xlink:href='#nonfoodallergies_sun'><text x='1683' y='1492'>nonfoodallergies_sun</text><title>nonfoodallergies_sun varchar&#040;100&#041;</title></a>
+  <a xlink:href='#nonfoodallergies_no'><text x='1683' y='1507'>nonfoodallergies_no</text><title>nonfoodallergies_no varchar&#040;100&#041;</title></a>
+  <a xlink:href='#ibd'><text x='1683' y='1522'>ibd</text><title>ibd varchar&#040;100&#041;</title></a>
+  <a xlink:href='#skin_condition'><text x='1683' y='1537'>skin_condition</text><title>skin_condition varchar&#040;100&#041;</title></a>
+  <a xlink:href='#diabetes'><text x='1683' y='1552'>diabetes</text><title>diabetes varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine'><text x='1683' y='1567'>migraine</text><title>migraine varchar&#040;100&#041;</title></a>
+  <a xlink:href='#protein_per'><text x='1683' y='1582'>protein_per</text><title>protein_per varchar&#040;100&#041;</title></a>
+  <a xlink:href='#fat_per'><text x='1683' y='1597'>fat_per</text><title>fat_per varchar&#040;100&#041;</title></a>
+  <a xlink:href='#carbohydrate_per'><text x='1683' y='1612'>carbohydrate_per</text><title>carbohydrate_per varchar&#040;100&#041;</title></a>
+  <a xlink:href='#plant_per'><text x='1683' y='1627'>plant_per</text><title>plant_per varchar&#040;100&#041;</title></a>
+  <a xlink:href='#animal_per'><text x='1683' y='1642'>animal_per</text><title>animal_per varchar&#040;100&#041;</title></a>
+  <a xlink:href='#fiber_grams'><text x='1683' y='1657'>fiber_grams</text><title>fiber_grams varchar&#040;100&#041;</title></a>
+  <a xlink:href='#types_of_plants'><text x='1683' y='1672'>types_of_plants</text><title>types_of_plants varchar&#040;100&#041;</title></a>
+  <a xlink:href='#percentage_from_carbs'><text x='1683' y='1687'>percentage_from_carbs</text><title>percentage_from_carbs varchar&#040;100&#041;</title></a>
+  <a xlink:href='#primary_vegetable'><text x='1683' y='1702'>primary_vegetable</text><title>primary_vegetable varchar&#040;100&#041;</title></a>
+  <a xlink:href='#primary_carb'><text x='1683' y='1717'>primary_carb</text><title>primary_carb varchar&#040;100&#041;</title></a>
+  <a xlink:href='#diabetes_diagnose_date'><text x='1683' y='1732'>diabetes_diagnose_date</text><title>diabetes_diagnose_date varchar&#040;100&#041;</title></a>
+  <a xlink:href='#diabetes_medication'><text x='1683' y='1747'>diabetes_medication</text><title>diabetes_medication varchar&#040;100&#041;</title></a>
+  <a xlink:href='#contraceptive'><text x='1683' y='1762'>contraceptive</text><title>contraceptive varchar&#040;100&#041;</title></a>
+  <a xlink:href='#pregnant'><text x='1683' y='1777'>pregnant</text><title>pregnant varchar&#040;100&#041;</title></a>
+  <a xlink:href='#pregnant_due_date'><text x='1683' y='1792'>pregnant_due_date</text><title>pregnant_due_date varchar&#040;100&#041;</title></a>
+  <a xlink:href='#frat'><text x='1683' y='1807'>frat</text><title>frat varchar&#040;100&#041;</title></a>
+  <a xlink:href='#communal_dining'><text x='1683' y='1822'>communal_dining</text><title>communal_dining varchar&#040;100&#041;</title></a>
+  <a xlink:href='#roommates'><text x='1683' y='1837'>roommates</text><title>roommates varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_frequency'><text x='1683' y='1852'>migraine_frequency</text><title>migraine_frequency varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_factor_1'><text x='1683' y='1867'>migraine_factor_1</text><title>migraine_factor_1 varchar&#040;100&#041;</title></a>
+  <a xlink:href='#mainfactor_other_1'><text x='1683' y='1882'>mainfactor_other_1</text><title>mainfactor_other_1 varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_factor_2'><text x='1683' y='1897'>migraine_factor_2</text><title>migraine_factor_2 varchar&#040;100&#041;</title></a>
+  <a xlink:href='#mainfactor_other_2'><text x='1683' y='1912'>mainfactor_other_2</text><title>mainfactor_other_2 varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_factor_3'><text x='1683' y='1927'>migraine_factor_3</text><title>migraine_factor_3 varchar&#040;100&#041;</title></a>
+  <a xlink:href='#mainfactor_other_3'><text x='1683' y='1942'>mainfactor_other_3</text><title>mainfactor_other_3 varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_pain'><text x='1683' y='1957'>migraine_pain</text><title>migraine_pain varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_photophobia'><text x='1683' y='1972'>migraine_photophobia</text><title>migraine_photophobia varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_phonophobia'><text x='1683' y='1987'>migraine_phonophobia</text><title>migraine_phonophobia varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_nausea'><text x='1683' y='2002'>migraine_nausea</text><title>migraine_nausea varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_aggravation'><text x='1683' y='2017'>migraine_aggravation</text><title>migraine_aggravation varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_aura'><text x='1683' y='2032'>migraine_aura</text><title>migraine_aura varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migraine_relatives'><text x='1683' y='2047'>migraine_relatives</text><title>migraine_relatives varchar&#040;100&#041;</title></a>
+  <a xlink:href='#migrainemeds'><text x='1683' y='2062'>migrainemeds</text><title>migrainemeds varchar&#040;100&#041;</title></a>
+  <a xlink:href='#about_yourself_text'><text x='1683' y='2077'>about_yourself_text</text><title>about_yourself_text varchar&#040;2000&#041;</title></a>
+  <a xlink:href='#participant_email'><text x='1683' y='2092'>participant_email</text><title>participant_email varchar&#040;300&#041;</title></a>
+  <a xlink:href='#participant_name_u'><text x='1683' y='2107'>participant_name_u</text><title>participant_name_u varchar&#040;400&#041;</title></a>
 
 <!-- ============= Table 'iso_country_lookup' ============= -->
-<rect class='table' x='945' y='1613' width='120' height='75' rx='7' ry='7' />
-<path d='M 945.50 1639.50 L 945.50 1620.50 Q 945.50 1613.50 952.50 1613.50 L 1057.50 1613.50 Q 1064.50 1613.50 1064.50 1620.50 L 1064.50 1639.50 L945.50 1639.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
-<a xlink:href='#iso_country_lookup'><text x='951' y='1627' class='tableTitle'>iso_country_lookup</text><title>Table ag.iso_country_lookup
+<rect class='table' x='900' y='1613' width='120' height='75' rx='7' ry='7' />
+<path d='M 900.50 1639.50 L 900.50 1620.50 Q 900.50 1613.50 907.50 1613.50 L 1012.50 1613.50 Q 1019.50 1613.50 1019.50 1620.50 L 1019.50 1639.50 L900.50 1639.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
+<a xlink:href='#iso_country_lookup'><text x='906' y='1627' class='tableTitle'>iso_country_lookup</text><title>Table ag.iso_country_lookup
 ISO standard codes for countries</title></a>
-  <use id='nn' x='947' y='1647' xlink:href='#nn'/><a xlink:href='#iso_code'><use id='pk' x='947' y='1646' xlink:href='#pk'/><title>Primary Key  ( iso_code ) </title></a>
-<a xlink:href='#iso_code'><text x='963' y='1657'>iso_code</text><title>iso_code varchar not null
+  <use id='nn' x='902' y='1647' xlink:href='#nn'/><a xlink:href='#iso_code'><use id='pk' x='902' y='1646' xlink:href='#pk'/><title>Primary Key  ( iso_code ) </title></a>
+<a xlink:href='#iso_code'><text x='918' y='1657'>iso_code</text><title>iso_code varchar not null
 The ISO code for the country</title></a>
-  <use id='nn' x='947' y='1662' xlink:href='#nn'/><a xlink:href='#country'><use id='idx' x='947' y='1661' xlink:href='#idx'/><title>Index  ( country ) </title></a>
-<a xlink:href='#country'><text x='963' y='1672'>country</text><title>country varchar not null</title></a>
-<a xlink:href='#country'><use id='fk' x='1053' y='1661' xlink:href='#fk'/><title>References survey_response ( country -> american ) </title></a>
+  <use id='nn' x='902' y='1662' xlink:href='#nn'/><a xlink:href='#country'><use id='idx' x='902' y='1661' xlink:href='#idx'/><title>Index  ( country ) </title></a>
+<a xlink:href='#country'><text x='918' y='1672'>country</text><title>country varchar not null</title></a>
+<a xlink:href='#country'><use id='fk' x='1008' y='1661' xlink:href='#fk'/><title>References survey_response ( country -> american ) </title></a>
 
 <!-- ============= Table 'survey_question_response_type' ============= -->
-<rect class='table' x='735' y='1718' width='195' height='75' rx='7' ry='7' />
-<path d='M 735.50 1744.50 L 735.50 1725.50 Q 735.50 1718.50 742.50 1718.50 L 922.50 1718.50 Q 929.50 1718.50 929.50 1725.50 L 929.50 1744.50 L735.50 1744.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
-<a xlink:href='#survey_question_response_type'><text x='745' y='1732' class='tableTitle'>survey_question_response_type</text><title>Table ag.survey_question_response_type
+<rect class='table' x='690' y='1718' width='195' height='75' rx='7' ry='7' />
+<path d='M 690.50 1744.50 L 690.50 1725.50 Q 690.50 1718.50 697.50 1718.50 L 877.50 1718.50 Q 884.50 1718.50 884.50 1725.50 L 884.50 1744.50 L690.50 1744.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#survey_question_response_type'><text x='700' y='1732' class='tableTitle'>survey_question_response_type</text><title>Table ag.survey_question_response_type
 Stores the type of response for each question</title></a>
-  <a xlink:href='#survey_question_id'><use id='idx' x='737' y='1751' xlink:href='#idx'/><title>Index  ( survey_question_id ) </title></a>
-<a xlink:href='#survey_question_id'><text x='753' y='1762'>survey_question_id</text><title>survey_question_id bigint</title></a>
-<a xlink:href='#survey_question_id'><use id='fk' x='918' y='1751' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
-  <use id='nn' x='737' y='1767' xlink:href='#nn'/><a xlink:href='#survey_response_type'><use id='idx' x='737' y='1766' xlink:href='#idx'/><title>Index  ( survey_response_type ) </title></a>
-<a xlink:href='#survey_response_type'><text x='753' y='1777'>survey_response_type</text><title>survey_response_type varchar not null</title></a>
-<a xlink:href='#survey_response_type'><use id='fk' x='918' y='1766' xlink:href='#fk'/><title>References survey_response_types ( survey_response_type ) </title></a>
+  <a xlink:href='#survey_question_id'><use id='idx' x='692' y='1751' xlink:href='#idx'/><title>Index  ( survey_question_id ) </title></a>
+<a xlink:href='#survey_question_id'><text x='708' y='1762'>survey_question_id</text><title>survey_question_id bigint</title></a>
+<a xlink:href='#survey_question_id'><use id='fk' x='873' y='1751' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
+  <use id='nn' x='692' y='1767' xlink:href='#nn'/><a xlink:href='#survey_response_type'><use id='idx' x='692' y='1766' xlink:href='#idx'/><title>Index  ( survey_response_type ) </title></a>
+<a xlink:href='#survey_response_type'><text x='708' y='1777'>survey_response_type</text><title>survey_response_type varchar not null</title></a>
+<a xlink:href='#survey_response_type'><use id='fk' x='873' y='1766' xlink:href='#fk'/><title>References survey_response_types ( survey_response_type ) </title></a>
 
 <!-- ============= Table 'ag_kit_barcodes' ============= -->
-<rect class='table' x='780' y='878' width='180' height='345' rx='7' ry='7' />
-<path d='M 780.50 904.50 L 780.50 885.50 Q 780.50 878.50 787.50 878.50 L 952.50 878.50 Q 959.50 878.50 959.50 885.50 L 959.50 904.50 L780.50 904.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#ag_kit_barcodes'><text x='826' y='892' class='tableTitle'>ag_kit_barcodes</text><title>Table ag.ag_kit_barcodes</title></a>
-  <use id='nn' x='782' y='912' xlink:href='#nn'/><a xlink:href='#ag_kit_barcode_id'><use id='pk' x='782' y='911' xlink:href='#pk'/><title>Primary Key  ( ag_kit_barcode_id ) </title></a>
-<a xlink:href='#ag_kit_barcode_id'><text x='798' y='922'>ag_kit_barcode_id</text><title>ag_kit_barcode_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
-  <a xlink:href='#ag_kit_id'><use id='idx' x='782' y='926' xlink:href='#idx'/><title>Index  ( ag_kit_id ) </title></a>
-<a xlink:href='#ag_kit_id'><text x='798' y='937'>ag_kit_id</text><title>ag_kit_id uuid</title></a>
-<a xlink:href='#ag_kit_id'><use id='fk' x='948' y='926' xlink:href='#fk'/><title>References ag_kit ( ag_kit_id ) </title></a>
-  <use id='nn' x='782' y='942' xlink:href='#nn'/><a xlink:href='#barcode'><use id='unq' x='782' y='941' xlink:href='#unq'/><title>Unique Index  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='798' y='952'>barcode</text><title>barcode varchar not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='948' y='941' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
-  <a xlink:href='#survey_id'><use id='idx' x='782' y='956' xlink:href='#idx'/><title>Index  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='798' y='967'>survey_id</text><title>survey_id varchar</title></a>
-<a xlink:href='#survey_id'><use id='fk' x='948' y='956' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
-  <a xlink:href='#sample_barcode_file'><text x='798' y='982'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;500&#041;</title></a>
-  <a xlink:href='#sample_barcode_file_md5'><text x='798' y='997'>sample_barcode_file_md5</text><title>sample_barcode_file_md5 varchar&#040;50&#041;</title></a>
-  <a xlink:href='#site_sampled'><text x='798' y='1012'>site_sampled</text><title>site_sampled varchar&#040;200&#041;</title></a>
-  <a xlink:href='#sample_date'><text x='798' y='1027'>sample_date</text><title>sample_date varchar&#040;20&#041;</title></a>
-  <a xlink:href='#participant_name'><text x='798' y='1042'>participant_name</text><title>participant_name varchar&#040;200&#041;</title></a>
-  <a xlink:href='#sample_time'><text x='798' y='1057'>sample_time</text><title>sample_time varchar&#040;100&#041;</title></a>
-  <a xlink:href='#notes'><text x='798' y='1072'>notes</text><title>notes varchar&#040;2000&#041;</title></a>
-  <a xlink:href='#environment_sampled'><text x='798' y='1087'>environment_sampled</text><title>environment_sampled varchar&#040;100&#041;</title></a>
-  <a xlink:href='#moldy'><text x='798' y='1102'>moldy</text><title>moldy char&#040;1&#041;</title></a>
-  <a xlink:href='#overloaded'><text x='798' y='1117'>overloaded</text><title>overloaded char&#040;1&#041;</title></a>
-  <a xlink:href='#other'><text x='798' y='1132'>other</text><title>other char&#040;1&#041;</title></a>
-  <a xlink:href='#other_text'><text x='798' y='1147'>other_text</text><title>other_text varchar&#040;2000&#041;</title></a>
-  <a xlink:href='#date_of_last_email'><text x='798' y='1162'>date_of_last_email</text><title>date_of_last_email varchar&#040;20&#041;</title></a>
-  <a xlink:href='#results_ready'><text x='798' y='1177'>results_ready</text><title>results_ready varchar&#040;1&#041;</title></a>
-  <a xlink:href='#withdrawn'><text x='798' y='1192'>withdrawn</text><title>withdrawn varchar&#040;1&#041;</title></a>
-  <a xlink:href='#refunded'><text x='798' y='1207'>refunded</text><title>refunded varchar&#040;1&#041;</title></a>
+<rect class='table' x='735' y='878' width='180' height='345' rx='7' ry='7' />
+<path d='M 735.50 904.50 L 735.50 885.50 Q 735.50 878.50 742.50 878.50 L 907.50 878.50 Q 914.50 878.50 914.50 885.50 L 914.50 904.50 L735.50 904.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#ag_kit_barcodes'><text x='781' y='892' class='tableTitle'>ag_kit_barcodes</text><title>Table ag.ag_kit_barcodes</title></a>
+  <use id='nn' x='737' y='912' xlink:href='#nn'/><a xlink:href='#ag_kit_barcode_id'><use id='pk' x='737' y='911' xlink:href='#pk'/><title>Primary Key  ( ag_kit_barcode_id ) </title></a>
+<a xlink:href='#ag_kit_barcode_id'><text x='753' y='922'>ag_kit_barcode_id</text><title>ag_kit_barcode_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
+  <a xlink:href='#ag_kit_id'><use id='idx' x='737' y='926' xlink:href='#idx'/><title>Index  ( ag_kit_id ) </title></a>
+<a xlink:href='#ag_kit_id'><text x='753' y='937'>ag_kit_id</text><title>ag_kit_id uuid</title></a>
+<a xlink:href='#ag_kit_id'><use id='fk' x='903' y='926' xlink:href='#fk'/><title>References ag_kit ( ag_kit_id ) </title></a>
+  <use id='nn' x='737' y='942' xlink:href='#nn'/><a xlink:href='#barcode'><use id='unq' x='737' y='941' xlink:href='#unq'/><title>Unique Index  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='753' y='952'>barcode</text><title>barcode varchar not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='903' y='941' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+  <a xlink:href='#survey_id'><use id='idx' x='737' y='956' xlink:href='#idx'/><title>Index  ( survey_id ) </title></a>
+<a xlink:href='#survey_id'><text x='753' y='967'>survey_id</text><title>survey_id varchar</title></a>
+<a xlink:href='#survey_id'><use id='fk' x='903' y='956' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
+  <a xlink:href='#sample_barcode_file'><text x='753' y='982'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;500&#041;</title></a>
+  <a xlink:href='#sample_barcode_file_md5'><text x='753' y='997'>sample_barcode_file_md5</text><title>sample_barcode_file_md5 varchar&#040;50&#041;</title></a>
+  <a xlink:href='#site_sampled'><text x='753' y='1012'>site_sampled</text><title>site_sampled varchar&#040;200&#041;</title></a>
+  <a xlink:href='#sample_date'><text x='753' y='1027'>sample_date</text><title>sample_date varchar&#040;20&#041;</title></a>
+  <a xlink:href='#participant_name'><text x='753' y='1042'>participant_name</text><title>participant_name varchar&#040;200&#041;</title></a>
+  <a xlink:href='#sample_time'><text x='753' y='1057'>sample_time</text><title>sample_time varchar&#040;100&#041;</title></a>
+  <a xlink:href='#notes'><text x='753' y='1072'>notes</text><title>notes varchar&#040;2000&#041;</title></a>
+  <a xlink:href='#environment_sampled'><text x='753' y='1087'>environment_sampled</text><title>environment_sampled varchar&#040;100&#041;</title></a>
+  <a xlink:href='#moldy'><text x='753' y='1102'>moldy</text><title>moldy char&#040;1&#041;</title></a>
+  <a xlink:href='#overloaded'><text x='753' y='1117'>overloaded</text><title>overloaded char&#040;1&#041;</title></a>
+  <a xlink:href='#other'><text x='753' y='1132'>other</text><title>other char&#040;1&#041;</title></a>
+  <a xlink:href='#other_text'><text x='753' y='1147'>other_text</text><title>other_text varchar&#040;2000&#041;</title></a>
+  <a xlink:href='#date_of_last_email'><text x='753' y='1162'>date_of_last_email</text><title>date_of_last_email varchar&#040;20&#041;</title></a>
+  <a xlink:href='#results_ready'><text x='753' y='1177'>results_ready</text><title>results_ready varchar&#040;1&#041;</title></a>
+  <a xlink:href='#withdrawn'><text x='753' y='1192'>withdrawn</text><title>withdrawn varchar&#040;1&#041;</title></a>
+  <a xlink:href='#refunded'><text x='753' y='1207'>refunded</text><title>refunded varchar&#040;1&#041;</title></a>
 
 <!-- ============= Table 'ag_login_surveys' ============= -->
-<rect class='table' x='1470' y='1013' width='135' height='105' rx='7' ry='7' />
-<path d='M 1470.50 1039.50 L 1470.50 1020.50 Q 1470.50 1013.50 1477.50 1013.50 L 1597.50 1013.50 Q 1604.50 1013.50 1604.50 1020.50 L 1604.50 1039.50 L1470.50 1039.50 ' style='fill:url(#tableHeaderGradient3); stroke:none;' />
-<a xlink:href='#ag_login_surveys'><text x='1490' y='1027' class='tableTitle'>ag_login_surveys</text><title>Table ag.ag_login_surveys</title></a>
-  <use id='nn' x='1472' y='1047' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='idx' x='1472' y='1046' xlink:href='#idx'/><title>Index  ( ag_login_id, participant_name ) </title></a>
-<a xlink:href='#ag_login_id'><text x='1488' y='1057'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
-<a xlink:href='#ag_login_id'><use id='fk' x='1593' y='1046' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) 
+<rect class='table' x='1425' y='1013' width='135' height='105' rx='7' ry='7' />
+<path d='M 1425.50 1039.50 L 1425.50 1020.50 Q 1425.50 1013.50 1432.50 1013.50 L 1552.50 1013.50 Q 1559.50 1013.50 1559.50 1020.50 L 1559.50 1039.50 L1425.50 1039.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
+<a xlink:href='#ag_login_surveys'><text x='1445' y='1027' class='tableTitle'>ag_login_surveys</text><title>Table ag.ag_login_surveys</title></a>
+  <use id='nn' x='1427' y='1047' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='idx' x='1427' y='1046' xlink:href='#idx'/><title>Index  ( ag_login_id, participant_name ) </title></a>
+<a xlink:href='#ag_login_id'><text x='1443' y='1057'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
+<a xlink:href='#ag_login_id'><use id='fk' x='1548' y='1046' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) 
 References ag_consent ( ag_login_id, participant_name ) </title></a>
-  <use id='nn' x='1472' y='1062' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1472' y='1061' xlink:href='#pk'/><title>Primary Key  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1488' y='1072'>survey_id</text><title>survey_id varchar not null</title></a>
-<a xlink:href='#survey_id'><use id='ref' x='1593' y='1061' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( survey_id ) 
+  <use id='nn' x='1427' y='1062' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1427' y='1061' xlink:href='#pk'/><title>Primary Key  ( survey_id ) </title></a>
+<a xlink:href='#survey_id'><text x='1443' y='1072'>survey_id</text><title>survey_id varchar not null</title></a>
+<a xlink:href='#survey_id'><use id='ref' x='1548' y='1061' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( survey_id ) 
 Referred by promoted_survey_ids ( survey_id ) 
 Referred by survey_answers ( survey_id ) 
 Referred by survey_answers_other ( survey_id ) </title></a>
-  <a xlink:href='#participant_name'><use id='idx' x='1472' y='1076' xlink:href='#idx'/><title>Index  ( participant_name ) Index  ( ag_login_id, participant_name ) </title></a>
-<a xlink:href='#participant_name'><text x='1488' y='1087'>participant_name</text><title>participant_name varchar</title></a>
-<a xlink:href='#participant_name'><use id='fk' x='1593' y='1076' xlink:href='#fk'/><title>References ag_consent ( ag_login_id, participant_name ) </title></a>
-  <a xlink:href='#vioscreen_status'><text x='1488' y='1102'>vioscreen_status</text><title>vioscreen_status integer</title></a>
+  <a xlink:href='#participant_name'><use id='idx' x='1427' y='1076' xlink:href='#idx'/><title>Index  ( participant_name ) Index  ( ag_login_id, participant_name ) </title></a>
+<a xlink:href='#participant_name'><text x='1443' y='1087'>participant_name</text><title>participant_name varchar</title></a>
+<a xlink:href='#participant_name'><use id='fk' x='1548' y='1076' xlink:href='#fk'/><title>References ag_consent ( ag_login_id, participant_name ) </title></a>
+  <a xlink:href='#vioscreen_status'><text x='1443' y='1102'>vioscreen_status</text><title>vioscreen_status integer</title></a>
 
 <!-- ============= Table 'survey_answers' ============= -->
-<rect class='table' x='1575' y='1193' width='135' height='90' rx='7' ry='7' />
-<path d='M 1575.50 1219.50 L 1575.50 1200.50 Q 1575.50 1193.50 1582.50 1193.50 L 1702.50 1193.50 Q 1709.50 1193.50 1709.50 1200.50 L 1709.50 1219.50 L1575.50 1219.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#survey_answers'><text x='1599' y='1207' class='tableTitle'>survey_answers</text><title>Table ag.survey_answers
+<rect class='table' x='1530' y='1193' width='135' height='90' rx='7' ry='7' />
+<path d='M 1530.50 1219.50 L 1530.50 1200.50 Q 1530.50 1193.50 1537.50 1193.50 L 1657.50 1193.50 Q 1664.50 1193.50 1664.50 1200.50 L 1664.50 1219.50 L1530.50 1219.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#survey_answers'><text x='1554' y='1207' class='tableTitle'>survey_answers</text><title>Table ag.survey_answers
 Stores answers to questions of type SINGLE and MULTIPLE</title></a>
-  <use id='nn' x='1577' y='1227' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1577' y='1226' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1593' y='1237'>survey_id</text><title>survey_id varchar not null
+  <use id='nn' x='1532' y='1227' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1532' y='1226' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_id ) </title></a>
+<a xlink:href='#survey_id'><text x='1548' y='1237'>survey_id</text><title>survey_id varchar not null
 The unique identifier for the survey</title></a>
-<a xlink:href='#survey_id'><use id='fk' x='1698' y='1226' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
-  <use id='nn' x='1577' y='1242' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='1577' y='1241' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_question_id, response ) </title></a>
-<a xlink:href='#survey_question_id'><text x='1593' y='1252'>survey_question_id</text><title>survey_question_id bigint not null
+<a xlink:href='#survey_id'><use id='fk' x='1653' y='1226' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
+  <use id='nn' x='1532' y='1242' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='1532' y='1241' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_question_id, response ) </title></a>
+<a xlink:href='#survey_question_id'><text x='1548' y='1252'>survey_question_id</text><title>survey_question_id bigint not null
 The question being answered</title></a>
-<a xlink:href='#survey_question_id'><use id='fk' x='1698' y='1241' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, response ) </title></a>
-  <use id='nn' x='1577' y='1257' xlink:href='#nn'/><a xlink:href='#response'><use id='pk' x='1577' y='1256' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_question_id, response ) </title></a>
-<a xlink:href='#response'><text x='1593' y='1267'>response</text><title>response varchar not null
+<a xlink:href='#survey_question_id'><use id='fk' x='1653' y='1241' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, response ) </title></a>
+  <use id='nn' x='1532' y='1257' xlink:href='#nn'/><a xlink:href='#response'><use id='pk' x='1532' y='1256' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_question_id, response ) </title></a>
+<a xlink:href='#response'><text x='1548' y='1267'>response</text><title>response varchar not null
 The answer the question being asked</title></a>
-<a xlink:href='#response'><use id='fk' x='1698' y='1256' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, response ) </title></a>
+<a xlink:href='#response'><use id='fk' x='1653' y='1256' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, response ) </title></a>
 
 <!-- ============= Table 'promoted_survey_ids' ============= -->
-<rect class='table' x='1470' y='908' width='135' height='60' rx='7' ry='7' />
-<path d='M 1470.50 934.50 L 1470.50 915.50 Q 1470.50 908.50 1477.50 908.50 L 1597.50 908.50 Q 1604.50 908.50 1604.50 915.50 L 1604.50 934.50 L1470.50 934.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#promoted_survey_ids'><text x='1479' y='922' class='tableTitle'>promoted_survey_ids</text><title>Table ag.promoted_survey_ids
+<rect class='table' x='1425' y='908' width='135' height='60' rx='7' ry='7' />
+<path d='M 1425.50 934.50 L 1425.50 915.50 Q 1425.50 908.50 1432.50 908.50 L 1552.50 908.50 Q 1559.50 908.50 1559.50 915.50 L 1559.50 934.50 L1425.50 934.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#promoted_survey_ids'><text x='1434' y='922' class='tableTitle'>promoted_survey_ids</text><title>Table ag.promoted_survey_ids
 Keeps track of the survey&#095;ids that correspond to surveys that were ported from first questionnaire to the second</title></a>
-  <use id='nn' x='1472' y='942' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1472' y='941' xlink:href='#pk'/><title>Primary Key  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1488' y='952'>survey_id</text><title>survey_id varchar not null</title></a>
-<a xlink:href='#survey_id'><use id='fk' x='1593' y='941' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
+  <use id='nn' x='1427' y='942' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1427' y='941' xlink:href='#pk'/><title>Primary Key  ( survey_id ) </title></a>
+<a xlink:href='#survey_id'><text x='1443' y='952'>survey_id</text><title>survey_id varchar not null</title></a>
+<a xlink:href='#survey_id'><use id='fk' x='1548' y='941' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
 
 <!-- ============= Table 'survey_question' ============= -->
-<rect class='table' x='465' y='1523' width='150' height='105' rx='7' ry='7' />
-<path d='M 465.50 1549.50 L 465.50 1530.50 Q 465.50 1523.50 472.50 1523.50 L 607.50 1523.50 Q 614.50 1523.50 614.50 1530.50 L 614.50 1549.50 L465.50 1549.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#survey_question'><text x='495' y='1537' class='tableTitle'>survey_question</text><title>Table ag.survey_question
+<rect class='table' x='420' y='1523' width='150' height='105' rx='7' ry='7' />
+<path d='M 420.50 1549.50 L 420.50 1530.50 Q 420.50 1523.50 427.50 1523.50 L 562.50 1523.50 Q 569.50 1523.50 569.50 1530.50 L 569.50 1549.50 L420.50 1549.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#survey_question'><text x='450' y='1537' class='tableTitle'>survey_question</text><title>Table ag.survey_question
 Stores the human survey questions</title></a>
-  <use id='nn' x='467' y='1557' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='467' y='1556' xlink:href='#pk'/><title>Primary Key  ( survey_question_id ) </title></a>
-<a xlink:href='#survey_question_id'><text x='483' y='1567'>survey_question_id</text><title>survey_question_id bigint not null
+  <use id='nn' x='422' y='1557' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='422' y='1556' xlink:href='#pk'/><title>Primary Key  ( survey_question_id ) </title></a>
+<a xlink:href='#survey_question_id'><text x='438' y='1567'>survey_question_id</text><title>survey_question_id bigint not null
 The unique question ID</title></a>
-<a xlink:href='#survey_question_id'><use id='ref' x='603' y='1556' xlink:href='#ref'/><title>Referred by group_questions ( survey_question_id ) 
+<a xlink:href='#survey_question_id'><use id='ref' x='558' y='1556' xlink:href='#ref'/><title>Referred by group_questions ( survey_question_id ) 
 Referred by survey_answers_other ( survey_question_id ) 
 Referred by survey_question_response ( survey_question_id ) 
 Referred by survey_question_response_type ( survey_question_id ) 
 Referred by survey_question_triggers ( triggered_question -> survey_question_id ) </title></a>
-  <use id='nn' x='467' y='1572' xlink:href='#nn'/><a xlink:href='#question_shortname'><use id='unq' x='467' y='1571' xlink:href='#unq'/><title>Unique Index  ( question_shortname ) </title></a>
-<a xlink:href='#question_shortname'><text x='483' y='1582'>question_shortname</text><title>question_shortname varchar&#040;100&#041; not null default &#039;TODO&#039;
+  <use id='nn' x='422' y='1572' xlink:href='#nn'/><a xlink:href='#question_shortname'><use id='unq' x='422' y='1571' xlink:href='#unq'/><title>Unique Index  ( question_shortname ) </title></a>
+<a xlink:href='#question_shortname'><text x='438' y='1582'>question_shortname</text><title>question_shortname varchar&#040;100&#041; not null default &#039;TODO&#039;
 A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown</title></a>
-  <a xlink:href='#american'><use id='unq' x='467' y='1586' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
-<a xlink:href='#american'><text x='483' y='1597'>american</text><title>american varchar
+  <a xlink:href='#american'><use id='unq' x='422' y='1586' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
+<a xlink:href='#american'><text x='438' y='1597'>american</text><title>american varchar
 The american english version of the question</title></a>
-  <a xlink:href='#british'><use id='unq' x='467' y='1601' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
-<a xlink:href='#british'><text x='483' y='1612'>british</text><title>british varchar
+  <a xlink:href='#british'><use id='unq' x='422' y='1601' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
+<a xlink:href='#british'><text x='438' y='1612'>british</text><title>british varchar
 The british english version of the question</title></a>
 
 <!-- ============= Table 'ag_login' ============= -->
-<rect class='table' x='750' y='398' width='120' height='225' rx='7' ry='7' />
-<path d='M 750.50 424.50 L 750.50 405.50 Q 750.50 398.50 757.50 398.50 L 862.50 398.50 Q 869.50 398.50 869.50 405.50 L 869.50 424.50 L750.50 424.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#ag_login'><text x='787' y='412' class='tableTitle'>ag_login</text><title>Table ag.ag_login</title></a>
-  <use id='nn' x='752' y='432' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='752' y='431' xlink:href='#pk'/><title>Primary Key  ( ag_login_id ) </title></a>
-<a xlink:href='#ag_login_id'><text x='768' y='442'>ag_login_id</text><title>ag_login_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
-<a xlink:href='#ag_login_id'><use id='ref' x='858' y='431' xlink:href='#ref'/><title>Referred by ag_animal_survey ( ag_login_id ) 
+<rect class='table' x='705' y='398' width='120' height='225' rx='7' ry='7' />
+<path d='M 705.50 424.50 L 705.50 405.50 Q 705.50 398.50 712.50 398.50 L 817.50 398.50 Q 824.50 398.50 824.50 405.50 L 824.50 424.50 L705.50 424.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#ag_login'><text x='742' y='412' class='tableTitle'>ag_login</text><title>Table ag.ag_login</title></a>
+  <use id='nn' x='707' y='432' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='707' y='431' xlink:href='#pk'/><title>Primary Key  ( ag_login_id ) </title></a>
+<a xlink:href='#ag_login_id'><text x='723' y='442'>ag_login_id</text><title>ag_login_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
+<a xlink:href='#ag_login_id'><use id='ref' x='813' y='431' xlink:href='#ref'/><title>Referred by ag_animal_survey ( ag_login_id ) 
 Referred by ag_consent ( ag_login_id ) 
 Referred by ag_human_survey ( ag_login_id ) 
 Referred by ag_kit ( ag_login_id ) 
@@ -865,202 +865,186 @@ Referred by ag_login_surveys ( ag_login_id )
 Referred by ag_participant_exceptions ( ag_login_id ) 
 Referred by ag_survey_answer ( ag_login_id ) 
 Referred by ag_survey_multiples ( ag_login_id ) </title></a>
-  <a xlink:href='#email'><text x='768' y='457'>email</text><title>email varchar&#040;100&#041;</title></a>
-  <a xlink:href='#name'><text x='768' y='472'>name</text><title>name varchar&#040;200&#041;</title></a>
-  <a xlink:href='#address'><text x='768' y='487'>address</text><title>address varchar&#040;500&#041;</title></a>
-  <a xlink:href='#city'><text x='768' y='502'>city</text><title>city varchar&#040;100&#041;</title></a>
-  <a xlink:href='#state'><text x='768' y='517'>state</text><title>state varchar&#040;100&#041;</title></a>
-  <a xlink:href='#zip'><text x='768' y='532'>zip</text><title>zip varchar&#040;10&#041;</title></a>
-  <a xlink:href='#country'><text x='768' y='547'>country</text><title>country varchar&#040;100&#041;</title></a>
-  <a xlink:href='#latitude'><text x='768' y='562'>latitude</text><title>latitude float8</title></a>
-  <a xlink:href='#longitude'><text x='768' y='577'>longitude</text><title>longitude float8</title></a>
-  <a xlink:href='#cannot_geocode'><text x='768' y='592'>cannot_geocode</text><title>cannot_geocode char&#040;1&#041;</title></a>
-  <a xlink:href='#elevation'><text x='768' y='607'>elevation</text><title>elevation float8</title></a>
+  <a xlink:href='#email'><text x='723' y='457'>email</text><title>email varchar&#040;100&#041;</title></a>
+  <a xlink:href='#name'><text x='723' y='472'>name</text><title>name varchar&#040;200&#041;</title></a>
+  <a xlink:href='#address'><text x='723' y='487'>address</text><title>address varchar&#040;500&#041;</title></a>
+  <a xlink:href='#city'><text x='723' y='502'>city</text><title>city varchar&#040;100&#041;</title></a>
+  <a xlink:href='#state'><text x='723' y='517'>state</text><title>state varchar&#040;100&#041;</title></a>
+  <a xlink:href='#zip'><text x='723' y='532'>zip</text><title>zip varchar&#040;10&#041;</title></a>
+  <a xlink:href='#country'><text x='723' y='547'>country</text><title>country varchar&#040;100&#041;</title></a>
+  <a xlink:href='#latitude'><text x='723' y='562'>latitude</text><title>latitude float8</title></a>
+  <a xlink:href='#longitude'><text x='723' y='577'>longitude</text><title>longitude float8</title></a>
+  <a xlink:href='#cannot_geocode'><text x='723' y='592'>cannot_geocode</text><title>cannot_geocode char&#040;1&#041;</title></a>
+  <a xlink:href='#elevation'><text x='723' y='607'>elevation</text><title>elevation float8</title></a>
 
 <!-- ============= Table 'zipcodes' ============= -->
-<rect class='table' x='1140' y='38' width='120' height='165' rx='7' ry='7' />
-<path d='M 1140.50 64.50 L 1140.50 45.50 Q 1140.50 38.50 1147.50 38.50 L 1252.50 38.50 Q 1259.50 38.50 1259.50 45.50 L 1259.50 64.50 L1140.50 64.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#zipcodes'><text x='1176' y='52' class='tableTitle'>zipcodes</text><title>Table ag.zipcodes</title></a>
-  <use id='nn' x='1142' y='72' xlink:href='#nn'/><a xlink:href='#zipcode'><use id='pk' x='1142' y='71' xlink:href='#pk'/><title>Primary Key  ( zipcode ) </title></a>
-<a xlink:href='#zipcode'><text x='1158' y='82'>zipcode</text><title>zipcode varchar not null</title></a>
-  <a xlink:href='#state'><text x='1158' y='97'>state</text><title>state varchar</title></a>
-  <a xlink:href='#fips_regions'><text x='1158' y='112'>fips_regions</text><title>fips_regions varchar</title></a>
-  <a xlink:href='#city'><text x='1158' y='127'>city</text><title>city varchar</title></a>
-  <a xlink:href='#latitude'><text x='1158' y='142'>latitude</text><title>latitude float8</title></a>
-  <a xlink:href='#longitude'><text x='1158' y='157'>longitude</text><title>longitude float8</title></a>
-  <a xlink:href='#elevation'><text x='1158' y='172'>elevation</text><title>elevation float8</title></a>
-  <a xlink:href='#cannot_geocode'><text x='1158' y='187'>cannot_geocode</text><title>cannot_geocode bool</title></a>
+<rect class='table' x='1095' y='38' width='120' height='165' rx='7' ry='7' />
+<path d='M 1095.50 64.50 L 1095.50 45.50 Q 1095.50 38.50 1102.50 38.50 L 1207.50 38.50 Q 1214.50 38.50 1214.50 45.50 L 1214.50 64.50 L1095.50 64.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
+<a xlink:href='#zipcodes'><text x='1131' y='52' class='tableTitle'>zipcodes</text><title>Table ag.zipcodes</title></a>
+  <use id='nn' x='1097' y='72' xlink:href='#nn'/><a xlink:href='#zipcode'><use id='pk' x='1097' y='71' xlink:href='#pk'/><title>Primary Key  ( zipcode ) </title></a>
+<a xlink:href='#zipcode'><text x='1113' y='82'>zipcode</text><title>zipcode varchar not null</title></a>
+  <a xlink:href='#state'><text x='1113' y='97'>state</text><title>state varchar</title></a>
+  <a xlink:href='#fips_regions'><text x='1113' y='112'>fips_regions</text><title>fips_regions varchar</title></a>
+  <a xlink:href='#city'><text x='1113' y='127'>city</text><title>city varchar</title></a>
+  <a xlink:href='#latitude'><text x='1113' y='142'>latitude</text><title>latitude float8</title></a>
+  <a xlink:href='#longitude'><text x='1113' y='157'>longitude</text><title>longitude float8</title></a>
+  <a xlink:href='#elevation'><text x='1113' y='172'>elevation</text><title>elevation float8</title></a>
+  <a xlink:href='#cannot_geocode'><text x='1113' y='187'>cannot_geocode</text><title>cannot_geocode bool</title></a>
 
 <!-- ============= Table 'ag_consent' ============= -->
-<rect class='table' x='1485' y='668' width='135' height='225' rx='7' ry='7' />
-<path d='M 1485.50 694.50 L 1485.50 675.50 Q 1485.50 668.50 1492.50 668.50 L 1612.50 668.50 Q 1619.50 668.50 1619.50 675.50 L 1619.50 694.50 L1485.50 694.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
-<a xlink:href='#ag_consent'><text x='1521' y='682' class='tableTitle'>ag_consent</text><title>Table ag.ag_consent</title></a>
-  <use id='nn' x='1487' y='702' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='1487' y='701' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) Index  ( ag_login_id ) </title></a>
-<a xlink:href='#ag_login_id'><text x='1503' y='712'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
-<a xlink:href='#ag_login_id'><use id='fk' x='1608' y='701' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) 
+<rect class='table' x='1440' y='668' width='135' height='225' rx='7' ry='7' />
+<path d='M 1440.50 694.50 L 1440.50 675.50 Q 1440.50 668.50 1447.50 668.50 L 1567.50 668.50 Q 1574.50 668.50 1574.50 675.50 L 1574.50 694.50 L1440.50 694.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
+<a xlink:href='#ag_consent'><text x='1476' y='682' class='tableTitle'>ag_consent</text><title>Table ag.ag_consent</title></a>
+  <use id='nn' x='1442' y='702' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='1442' y='701' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) Index  ( ag_login_id ) </title></a>
+<a xlink:href='#ag_login_id'><text x='1458' y='712'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
+<a xlink:href='#ag_login_id'><use id='fk' x='1563' y='701' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) 
 Referred by ag_login_surveys ( ag_login_id, participant_name ) </title></a>
-  <use id='nn' x='1487' y='717' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='1487' y='716' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
-<a xlink:href='#participant_name'><text x='1503' y='727'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
-<a xlink:href='#participant_name'><use id='ref' x='1608' y='716' xlink:href='#ref'/><title>Referred by ag_login_surveys ( ag_login_id, participant_name ) </title></a>
-  <use id='nn' x='1487' y='732' xlink:href='#nn'/><a xlink:href='#participant_email'><text x='1503' y='742'>participant_email</text><title>participant_email varchar not null</title></a>
-  <a xlink:href='#is_juvenile'><text x='1503' y='757'>is_juvenile</text><title>is_juvenile bool</title></a>
-  <a xlink:href='#parent_1_name'><text x='1503' y='772'>parent_1_name</text><title>parent_1_name varchar&#040;200&#041;</title></a>
-  <a xlink:href='#parent_2_name'><text x='1503' y='787'>parent_2_name</text><title>parent_2_name varchar&#040;200&#041;</title></a>
-  <a xlink:href='#parent_1_code'><text x='1503' y='802'>parent_1_code</text><title>parent_1_code varchar&#040;200&#041;</title></a>
-  <a xlink:href='#parent_2_code'><text x='1503' y='817'>parent_2_code</text><title>parent_2_code varchar&#040;200&#041;</title></a>
-  <a xlink:href='#deceased_parent'><text x='1503' y='832'>deceased_parent</text><title>deceased_parent varchar&#040;10&#041;</title></a>
-  <a xlink:href='#date_signed'><text x='1503' y='847'>date_signed</text><title>date_signed date</title></a>
-  <a xlink:href='#assent_obtainer'><text x='1503' y='862'>assent_obtainer</text><title>assent_obtainer varchar</title></a>
-  <a xlink:href='#age_range'><text x='1503' y='877'>age_range</text><title>age_range varchar</title></a>
+  <use id='nn' x='1442' y='717' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='1442' y='716' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
+<a xlink:href='#participant_name'><text x='1458' y='727'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
+<a xlink:href='#participant_name'><use id='ref' x='1563' y='716' xlink:href='#ref'/><title>Referred by ag_login_surveys ( ag_login_id, participant_name ) </title></a>
+  <use id='nn' x='1442' y='732' xlink:href='#nn'/><a xlink:href='#participant_email'><text x='1458' y='742'>participant_email</text><title>participant_email varchar not null</title></a>
+  <a xlink:href='#is_juvenile'><text x='1458' y='757'>is_juvenile</text><title>is_juvenile bool</title></a>
+  <a xlink:href='#parent_1_name'><text x='1458' y='772'>parent_1_name</text><title>parent_1_name varchar&#040;200&#041;</title></a>
+  <a xlink:href='#parent_2_name'><text x='1458' y='787'>parent_2_name</text><title>parent_2_name varchar&#040;200&#041;</title></a>
+  <a xlink:href='#parent_1_code'><text x='1458' y='802'>parent_1_code</text><title>parent_1_code varchar&#040;200&#041;</title></a>
+  <a xlink:href='#parent_2_code'><text x='1458' y='817'>parent_2_code</text><title>parent_2_code varchar&#040;200&#041;</title></a>
+  <a xlink:href='#deceased_parent'><text x='1458' y='832'>deceased_parent</text><title>deceased_parent varchar&#040;10&#041;</title></a>
+  <a xlink:href='#date_signed'><text x='1458' y='847'>date_signed</text><title>date_signed date</title></a>
+  <a xlink:href='#assent_obtainer'><text x='1458' y='862'>assent_obtainer</text><title>assent_obtainer varchar</title></a>
+  <a xlink:href='#age_range'><text x='1458' y='877'>age_range</text><title>age_range varchar</title></a>
 
 <!-- ============= Table 'ag_survey_multiples_backup' ============= -->
-<rect class='table' x='195' y='323' width='180' height='105' rx='7' ry='7' />
-<path d='M 195.50 349.50 L 195.50 330.50 Q 195.50 323.50 202.50 323.50 L 367.50 323.50 Q 374.50 323.50 374.50 330.50 L 374.50 349.50 L195.50 349.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#ag_survey_multiples_backup'><text x='207' y='337' class='tableTitle'>ag_survey_multiples_backup</text><title>Table ag.ag_survey_multiples_backup</title></a>
-  <use id='nn' x='197' y='357' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='idx' x='197' y='356' xlink:href='#idx'/><title>Index  ( ag_login_id ) </title></a>
-<a xlink:href='#ag_login_id'><text x='213' y='367'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
-  <a xlink:href='#participant_name'><use id='idx' x='197' y='371' xlink:href='#idx'/><title>Index  ( participant_name ) </title></a>
-<a xlink:href='#participant_name'><text x='213' y='382'>participant_name</text><title>participant_name varchar&#040;200&#041;</title></a>
-  <use id='nn' x='197' y='387' xlink:href='#nn'/><a xlink:href='#item_name'><text x='213' y='397'>item_name</text><title>item_name varchar&#040;50&#041; not null</title></a>
-  <a xlink:href='#item_value'><text x='213' y='412'>item_value</text><title>item_value varchar&#040;1000&#041;</title></a>
+<rect class='table' x='195' y='83' width='180' height='105' rx='7' ry='7' />
+<path d='M 195.50 109.50 L 195.50 90.50 Q 195.50 83.50 202.50 83.50 L 367.50 83.50 Q 374.50 83.50 374.50 90.50 L 374.50 109.50 L195.50 109.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
+<a xlink:href='#ag_survey_multiples_backup'><text x='207' y='97' class='tableTitle'>ag_survey_multiples_backup</text><title>Table ag.ag_survey_multiples_backup</title></a>
+  <use id='nn' x='197' y='117' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='idx' x='197' y='116' xlink:href='#idx'/><title>Index  ( ag_login_id ) </title></a>
+<a xlink:href='#ag_login_id'><text x='213' y='127'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
+  <a xlink:href='#participant_name'><use id='idx' x='197' y='131' xlink:href='#idx'/><title>Index  ( participant_name ) </title></a>
+<a xlink:href='#participant_name'><text x='213' y='142'>participant_name</text><title>participant_name varchar&#040;200&#041;</title></a>
+  <use id='nn' x='197' y='147' xlink:href='#nn'/><a xlink:href='#item_name'><text x='213' y='157'>item_name</text><title>item_name varchar&#040;50&#041; not null</title></a>
+  <a xlink:href='#item_value'><text x='213' y='172'>item_value</text><title>item_value varchar&#040;1000&#041;</title></a>
 
 <!-- ============= Table 'ag_import_stats_tmp' ============= -->
-<rect class='table' x='420' y='323' width='165' height='225' rx='7' ry='7' />
-<path d='M 420.50 349.50 L 420.50 330.50 Q 420.50 323.50 427.50 323.50 L 577.50 323.50 Q 584.50 323.50 584.50 330.50 L 584.50 349.50 L420.50 349.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#ag_import_stats_tmp'><text x='445' y='337' class='tableTitle'>ag_import_stats_tmp</text><title>Table ag.ag_import_stats_tmp</title></a>
-  <a xlink:href='#tmp_login_count'><text x='438' y='367'>tmp_login_count</text><title>tmp_login_count bigint</title></a>
-  <a xlink:href='#tmp_kit_count'><text x='438' y='382'>tmp_kit_count</text><title>tmp_kit_count bigint</title></a>
-  <a xlink:href='#tmp_barcode_count'><text x='438' y='397'>tmp_barcode_count</text><title>tmp_barcode_count bigint</title></a>
-  <a xlink:href='#before_login_count'><text x='438' y='412'>before_login_count</text><title>before_login_count bigint</title></a>
-  <a xlink:href='#before_kit_count'><text x='438' y='427'>before_kit_count</text><title>before_kit_count bigint</title></a>
-  <a xlink:href='#before_barcode_count'><text x='438' y='442'>before_barcode_count</text><title>before_barcode_count bigint</title></a>
-  <a xlink:href='#after_login_count'><text x='438' y='457'>after_login_count</text><title>after_login_count bigint</title></a>
-  <a xlink:href='#after_kit_count'><text x='438' y='472'>after_kit_count</text><title>after_kit_count bigint</title></a>
-  <a xlink:href='#after_barcode_count'><text x='438' y='487'>after_barcode_count</text><title>after_barcode_count bigint</title></a>
-  <a xlink:href='#login_diff'><text x='438' y='502'>login_diff</text><title>login_diff bigint</title></a>
-  <a xlink:href='#kit_diff'><text x='438' y='517'>kit_diff</text><title>kit_diff bigint</title></a>
-  <a xlink:href='#barcode_diff'><text x='438' y='532'>barcode_diff</text><title>barcode_diff bigint</title></a>
+<rect class='table' x='420' y='83' width='165' height='225' rx='7' ry='7' />
+<path d='M 420.50 109.50 L 420.50 90.50 Q 420.50 83.50 427.50 83.50 L 577.50 83.50 Q 584.50 83.50 584.50 90.50 L 584.50 109.50 L420.50 109.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
+<a xlink:href='#ag_import_stats_tmp'><text x='445' y='97' class='tableTitle'>ag_import_stats_tmp</text><title>Table ag.ag_import_stats_tmp</title></a>
+  <a xlink:href='#tmp_login_count'><text x='438' y='127'>tmp_login_count</text><title>tmp_login_count bigint</title></a>
+  <a xlink:href='#tmp_kit_count'><text x='438' y='142'>tmp_kit_count</text><title>tmp_kit_count bigint</title></a>
+  <a xlink:href='#tmp_barcode_count'><text x='438' y='157'>tmp_barcode_count</text><title>tmp_barcode_count bigint</title></a>
+  <a xlink:href='#before_login_count'><text x='438' y='172'>before_login_count</text><title>before_login_count bigint</title></a>
+  <a xlink:href='#before_kit_count'><text x='438' y='187'>before_kit_count</text><title>before_kit_count bigint</title></a>
+  <a xlink:href='#before_barcode_count'><text x='438' y='202'>before_barcode_count</text><title>before_barcode_count bigint</title></a>
+  <a xlink:href='#after_login_count'><text x='438' y='217'>after_login_count</text><title>after_login_count bigint</title></a>
+  <a xlink:href='#after_kit_count'><text x='438' y='232'>after_kit_count</text><title>after_kit_count bigint</title></a>
+  <a xlink:href='#after_barcode_count'><text x='438' y='247'>after_barcode_count</text><title>after_barcode_count bigint</title></a>
+  <a xlink:href='#login_diff'><text x='438' y='262'>login_diff</text><title>login_diff bigint</title></a>
+  <a xlink:href='#kit_diff'><text x='438' y='277'>kit_diff</text><title>kit_diff bigint</title></a>
+  <a xlink:href='#barcode_diff'><text x='438' y='292'>barcode_diff</text><title>barcode_diff bigint</title></a>
 
 <!-- ============= Table 'barcode' ============= -->
-<rect class='table' x='420' y='623' width='165' height='165' rx='7' ry='7' />
-<path d='M 420.50 649.50 L 420.50 630.50 Q 420.50 623.50 427.50 623.50 L 577.50 623.50 Q 584.50 623.50 584.50 630.50 L 584.50 649.50 L420.50 649.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#barcode'><text x='480' y='637' class='tableTitle'>barcode</text><title>Table ag.barcode</title></a>
-  <use id='nn' x='422' y='657' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='422' y='656' xlink:href='#pk'/><title>Primary Key  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='438' y='667'>barcode</text><title>barcode varchar not null</title></a>
-<a xlink:href='#barcode'><use id='ref' x='573' y='656' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( barcode ) 
-Referred by plate_barcode ( barcode ) 
-Referred by project_barcode ( barcode ) 
-Referred by ag_handout_kits ( barcode ) 
-Referred by ag_handout_kits ( barcode ) 
+<rect class='table' x='375' y='623' width='165' height='165' rx='7' ry='7' />
+<path d='M 375.50 649.50 L 375.50 630.50 Q 375.50 623.50 382.50 623.50 L 532.50 623.50 Q 539.50 623.50 539.50 630.50 L 539.50 649.50 L375.50 649.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
+<a xlink:href='#barcode'><text x='435' y='637' class='tableTitle'>barcode</text><title>Table ag.barcode</title></a>
+  <use id='nn' x='377' y='657' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='377' y='656' xlink:href='#pk'/><title>Primary Key  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='393' y='667'>barcode</text><title>barcode varchar not null</title></a>
+<a xlink:href='#barcode'><use id='ref' x='528' y='656' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( barcode ) 
 Referred by barcode_exceptions ( barcode ) 
-Referred by barcode_exceptions ( barcode ) </title></a>
-  <a xlink:href='#create_date_time'><text x='438' y='682'>create_date_time</text><title>create_date_time timestamp default &#040;&#039;now&#039;&#058;&#058;text&#041;&#058;&#058;timestamp without time zone</title></a>
-  <a xlink:href='#status'><text x='438' y='697'>status</text><title>status varchar&#040;100&#041;</title></a>
-  <a xlink:href='#scan_date'><text x='438' y='712'>scan_date</text><title>scan_date varchar&#040;20&#041;</title></a>
-  <a xlink:href='#sample_postmark_date'><text x='438' y='727'>sample_postmark_date</text><title>sample_postmark_date varchar&#040;20&#041;</title></a>
-  <a xlink:href='#biomass_remaining'><text x='438' y='742'>biomass_remaining</text><title>biomass_remaining varchar&#040;1&#041;</title></a>
-  <a xlink:href='#sequencing_status'><text x='438' y='757'>sequencing_status</text><title>sequencing_status varchar&#040;20&#041;</title></a>
-  <a xlink:href='#obsolete'><text x='438' y='772'>obsolete</text><title>obsolete varchar&#040;1&#041;</title></a>
+Referred by handout_barcode ( barcode ) 
+Referred by plate_barcode ( barcode ) 
+Referred by project_barcode ( barcode ) </title></a>
+  <a xlink:href='#create_date_time'><text x='393' y='682'>create_date_time</text><title>create_date_time timestamp default &#040;&#039;now&#039;&#058;&#058;text&#041;&#058;&#058;timestamp without time zone</title></a>
+  <a xlink:href='#status'><text x='393' y='697'>status</text><title>status varchar&#040;100&#041;</title></a>
+  <a xlink:href='#scan_date'><text x='393' y='712'>scan_date</text><title>scan_date varchar&#040;20&#041;</title></a>
+  <a xlink:href='#sample_postmark_date'><text x='393' y='727'>sample_postmark_date</text><title>sample_postmark_date varchar&#040;20&#041;</title></a>
+  <a xlink:href='#biomass_remaining'><text x='393' y='742'>biomass_remaining</text><title>biomass_remaining varchar&#040;1&#041;</title></a>
+  <a xlink:href='#sequencing_status'><text x='393' y='757'>sequencing_status</text><title>sequencing_status varchar&#040;20&#041;</title></a>
+  <a xlink:href='#obsolete'><text x='393' y='772'>obsolete</text><title>obsolete varchar&#040;1&#041;</title></a>
 
 <!-- ============= Table 'project_barcode' ============= -->
-<rect class='table' x='450' y='938' width='105' height='75' rx='7' ry='7' />
-<path d='M 450.50 964.50 L 450.50 945.50 Q 450.50 938.50 457.50 938.50 L 547.50 938.50 Q 554.50 938.50 554.50 945.50 L 554.50 964.50 L450.50 964.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
-<a xlink:href='#project_barcode'><text x='458' y='952' class='tableTitle'>project_barcode</text><title>Table ag.project_barcode</title></a>
-  <use id='nn' x='452' y='972' xlink:href='#nn'/><a xlink:href='#project_id'><use id='pk' x='452' y='971' xlink:href='#pk'/><title>Primary Key  ( project_id, barcode ) </title></a>
-<a xlink:href='#project_id'><text x='468' y='982'>project_id</text><title>project_id bigint not null</title></a>
-<a xlink:href='#project_id'><use id='fk' x='543' y='971' xlink:href='#fk'/><title>References project ( project_id ) </title></a>
-  <use id='nn' x='452' y='987' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='452' y='986' xlink:href='#pk'/><title>Primary Key  ( project_id, barcode ) </title></a>
-<a xlink:href='#barcode'><text x='468' y='997'>barcode</text><title>barcode char&#040;9&#041; not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='543' y='986' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+<rect class='table' x='405' y='938' width='105' height='75' rx='7' ry='7' />
+<path d='M 405.50 964.50 L 405.50 945.50 Q 405.50 938.50 412.50 938.50 L 502.50 938.50 Q 509.50 938.50 509.50 945.50 L 509.50 964.50 L405.50 964.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
+<a xlink:href='#project_barcode'><text x='413' y='952' class='tableTitle'>project_barcode</text><title>Table ag.project_barcode</title></a>
+  <use id='nn' x='407' y='972' xlink:href='#nn'/><a xlink:href='#project_id'><use id='pk' x='407' y='971' xlink:href='#pk'/><title>Primary Key  ( project_id, barcode ) </title></a>
+<a xlink:href='#project_id'><text x='423' y='982'>project_id</text><title>project_id bigint not null</title></a>
+<a xlink:href='#project_id'><use id='fk' x='498' y='971' xlink:href='#fk'/><title>References project ( project_id ) </title></a>
+  <use id='nn' x='407' y='987' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='407' y='986' xlink:href='#pk'/><title>Primary Key  ( project_id, barcode ) </title></a>
+<a xlink:href='#barcode'><text x='423' y='997'>barcode</text><title>barcode char&#040;9&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='498' y='986' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
 
 <!-- ============= Table 'plate' ============= -->
-<rect class='table' x='435' y='1028' width='120' height='90' rx='7' ry='7' />
-<path d='M 435.50 1054.50 L 435.50 1035.50 Q 435.50 1028.50 442.50 1028.50 L 547.50 1028.50 Q 554.50 1028.50 554.50 1035.50 L 554.50 1054.50 L435.50 1054.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
-<a xlink:href='#plate'><text x='482' y='1042' class='tableTitle'>plate</text><title>Table ag.plate</title></a>
-  <use id='nn' x='437' y='1062' xlink:href='#nn'/><a xlink:href='#plate_id'><use id='pk' x='437' y='1061' xlink:href='#pk'/><title>Primary Key  ( plate_id ) </title></a>
-<a xlink:href='#plate_id'><text x='453' y='1072'>plate_id</text><title>plate_id bigint not null</title></a>
-<a xlink:href='#plate_id'><use id='ref' x='543' y='1061' xlink:href='#ref'/><title>Referred by plate_barcode ( plate_id ) </title></a>
-  <a xlink:href='#plate'><text x='453' y='1087'>plate</text><title>plate varchar&#040;50&#041;</title></a>
-  <a xlink:href='#sequence_date'><text x='453' y='1102'>sequence_date</text><title>sequence_date varchar&#040;20&#041;</title></a>
+<rect class='table' x='390' y='1028' width='120' height='90' rx='7' ry='7' />
+<path d='M 390.50 1054.50 L 390.50 1035.50 Q 390.50 1028.50 397.50 1028.50 L 502.50 1028.50 Q 509.50 1028.50 509.50 1035.50 L 509.50 1054.50 L390.50 1054.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
+<a xlink:href='#plate'><text x='437' y='1042' class='tableTitle'>plate</text><title>Table ag.plate</title></a>
+  <use id='nn' x='392' y='1062' xlink:href='#nn'/><a xlink:href='#plate_id'><use id='pk' x='392' y='1061' xlink:href='#pk'/><title>Primary Key  ( plate_id ) </title></a>
+<a xlink:href='#plate_id'><text x='408' y='1072'>plate_id</text><title>plate_id bigint not null</title></a>
+<a xlink:href='#plate_id'><use id='ref' x='498' y='1061' xlink:href='#ref'/><title>Referred by plate_barcode ( plate_id ) </title></a>
+  <a xlink:href='#plate'><text x='408' y='1087'>plate</text><title>plate varchar&#040;50&#041;</title></a>
+  <a xlink:href='#sequence_date'><text x='408' y='1102'>sequence_date</text><title>sequence_date varchar&#040;20&#041;</title></a>
 
 <!-- ============= Table 'plate_barcode' ============= -->
-<rect class='table' x='450' y='1133' width='90' height='75' rx='7' ry='7' />
-<path d='M 450.50 1159.50 L 450.50 1140.50 Q 450.50 1133.50 457.50 1133.50 L 532.50 1133.50 Q 539.50 1133.50 539.50 1140.50 L 539.50 1159.50 L450.50 1159.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
-<a xlink:href='#plate_barcode'><text x='457' y='1147' class='tableTitle'>plate_barcode</text><title>Table ag.plate_barcode</title></a>
-  <use id='nn' x='452' y='1167' xlink:href='#nn'/><a xlink:href='#plate_id'><use id='idx' x='452' y='1166' xlink:href='#idx'/><title>Index  ( plate_id ) </title></a>
-<a xlink:href='#plate_id'><text x='468' y='1177'>plate_id</text><title>plate_id bigint not null</title></a>
-<a xlink:href='#plate_id'><use id='fk' x='528' y='1166' xlink:href='#fk'/><title>References plate ( plate_id ) </title></a>
-  <use id='nn' x='452' y='1182' xlink:href='#nn'/><a xlink:href='#barcode'><use id='idx' x='452' y='1181' xlink:href='#idx'/><title>Index  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='468' y='1192'>barcode</text><title>barcode varchar not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='528' y='1181' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+<rect class='table' x='405' y='1133' width='90' height='75' rx='7' ry='7' />
+<path d='M 405.50 1159.50 L 405.50 1140.50 Q 405.50 1133.50 412.50 1133.50 L 487.50 1133.50 Q 494.50 1133.50 494.50 1140.50 L 494.50 1159.50 L405.50 1159.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
+<a xlink:href='#plate_barcode'><text x='412' y='1147' class='tableTitle'>plate_barcode</text><title>Table ag.plate_barcode</title></a>
+  <use id='nn' x='407' y='1167' xlink:href='#nn'/><a xlink:href='#plate_id'><use id='idx' x='407' y='1166' xlink:href='#idx'/><title>Index  ( plate_id ) </title></a>
+<a xlink:href='#plate_id'><text x='423' y='1177'>plate_id</text><title>plate_id bigint not null</title></a>
+<a xlink:href='#plate_id'><use id='fk' x='483' y='1166' xlink:href='#fk'/><title>References plate ( plate_id ) </title></a>
+  <use id='nn' x='407' y='1182' xlink:href='#nn'/><a xlink:href='#barcode'><use id='idx' x='407' y='1181' xlink:href='#idx'/><title>Index  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='423' y='1192'>barcode</text><title>barcode varchar not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='483' y='1181' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
 
 <!-- ============= Table 'project' ============= -->
-<rect class='table' x='450' y='848' width='90' height='75' rx='7' ry='7' />
-<path d='M 450.50 874.50 L 450.50 855.50 Q 450.50 848.50 457.50 848.50 L 532.50 848.50 Q 539.50 848.50 539.50 855.50 L 539.50 874.50 L450.50 874.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
-<a xlink:href='#project'><text x='476' y='862' class='tableTitle'>project</text><title>Table ag.project</title></a>
-  <use id='nn' x='452' y='882' xlink:href='#nn'/><a xlink:href='#project_id'><use id='pk' x='452' y='881' xlink:href='#pk'/><title>Primary Key  ( project_id ) </title></a>
-<a xlink:href='#project_id'><text x='468' y='892'>project_id</text><title>project_id bigint not null</title></a>
-<a xlink:href='#project_id'><use id='ref' x='528' y='881' xlink:href='#ref'/><title>Referred by project_barcode ( project_id ) </title></a>
-  <a xlink:href='#project'><text x='468' y='907'>project</text><title>project varchar&#040;1000&#041;</title></a>
+<rect class='table' x='405' y='848' width='90' height='75' rx='7' ry='7' />
+<path d='M 405.50 874.50 L 405.50 855.50 Q 405.50 848.50 412.50 848.50 L 487.50 848.50 Q 494.50 848.50 494.50 855.50 L 494.50 874.50 L405.50 874.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
+<a xlink:href='#project'><text x='431' y='862' class='tableTitle'>project</text><title>Table ag.project</title></a>
+  <use id='nn' x='407' y='882' xlink:href='#nn'/><a xlink:href='#project_id'><use id='pk' x='407' y='881' xlink:href='#pk'/><title>Primary Key  ( project_id ) </title></a>
+<a xlink:href='#project_id'><text x='423' y='892'>project_id</text><title>project_id bigint not null</title></a>
+<a xlink:href='#project_id'><use id='ref' x='483' y='881' xlink:href='#ref'/><title>Referred by project_barcode ( project_id ) </title></a>
+  <a xlink:href='#project'><text x='423' y='907'>project</text><title>project varchar&#040;1000&#041;</title></a>
 
 <!-- ============= Table 'barcode_exceptions' ============= -->
-<rect class='table' x='90' y='1058' width='120' height='60' rx='7' ry='7' />
-<path d='M 90.50 1084.50 L 90.50 1065.50 Q 90.50 1058.50 97.50 1058.50 L 202.50 1058.50 Q 209.50 1058.50 209.50 1065.50 L 209.50 1084.50 L90.50 1084.50 ' style='fill:url(#tableHeaderGradient2); stroke:none;' />
-<a xlink:href='#barcode_exceptions'><text x='95' y='1072' class='tableTitle'>barcode_exceptions</text><title>Table ag.barcode_exceptions</title></a>
-  <use id='nn' x='92' y='1092' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='92' y='1091' xlink:href='#pk'/><title>Primary Key  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='108' y='1102'>barcode</text><title>barcode varchar&#040;100&#041; not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='198' y='1091' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+<rect class='table' x='45' y='1058' width='120' height='60' rx='7' ry='7' />
+<path d='M 45.50 1084.50 L 45.50 1065.50 Q 45.50 1058.50 52.50 1058.50 L 157.50 1058.50 Q 164.50 1058.50 164.50 1065.50 L 164.50 1084.50 L45.50 1084.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
+<a xlink:href='#barcode_exceptions'><text x='50' y='1072' class='tableTitle'>barcode_exceptions</text><title>Table ag.barcode_exceptions</title></a>
+  <use id='nn' x='47' y='1092' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='47' y='1091' xlink:href='#pk'/><title>Primary Key  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='63' y='1102'>barcode</text><title>barcode varchar&#040;100&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='153' y='1091' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+
+<!-- ============= Table 'ag_map_markers' ============= -->
+<rect class='table' x='60' y='83' width='105' height='120' rx='7' ry='7' />
+<path d='M 60.50 109.50 L 60.50 90.50 Q 60.50 83.50 67.50 83.50 L 157.50 83.50 Q 164.50 83.50 164.50 90.50 L 164.50 109.50 L60.50 109.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
+<a xlink:href='#ag_map_markers'><text x='66' y='97' class='tableTitle'>ag_map_markers</text><title>Table ag.ag_map_markers</title></a>
+  <a xlink:href='#zipcode'><text x='78' y='127'>zipcode</text><title>zipcode varchar&#040;20&#041;</title></a>
+  <a xlink:href='#latitude'><text x='78' y='142'>latitude</text><title>latitude float8</title></a>
+  <a xlink:href='#longitude'><text x='78' y='157'>longitude</text><title>longitude float8</title></a>
+  <a xlink:href='#marker_color'><text x='78' y='172'>marker_color</text><title>marker_color varchar&#040;10&#041;</title></a>
+  <a xlink:href='#order_by'><text x='78' y='187'>order_by</text><title>order_by bigint</title></a>
+
+<!-- ============= Table 'handout_barcode' ============= -->
+<rect class='table' x='255' y='413' width='150' height='90' rx='7' ry='7' />
+<path d='M 255.50 439.50 L 255.50 420.50 Q 255.50 413.50 262.50 413.50 L 397.50 413.50 Q 404.50 413.50 404.50 420.50 L 404.50 439.50 L255.50 439.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#handout_barcode'><text x='282' y='427' class='tableTitle'>handout_barcode</text><title>Table ag.handout_barcode</title></a>
+  <use id='nn' x='257' y='447' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='257' y='446' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) Index  ( kit_id ) </title></a>
+<a xlink:href='#kit_id'><text x='273' y='457'>kit_id</text><title>kit_id varchar not null</title></a>
+<a xlink:href='#kit_id'><use id='fk' x='393' y='446' xlink:href='#fk'/><title>References ag_handout_kits ( kit_id ) </title></a>
+  <use id='nn' x='257' y='462' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='257' y='461' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) Index  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='273' y='472'>barcode</text><title>barcode varchar&#040;9&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='393' y='461' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+  <use id='nn' x='257' y='477' xlink:href='#nn'/><a xlink:href='#sample_barcode_file'><text x='273' y='487'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;13&#041; not null</title></a>
 
 <!-- ============= Table 'ag_handout_kits' ============= -->
-<rect class='table' x='90' y='863' width='150' height='150' rx='7' ry='7' />
-<path d='M 90.50 889.50 L 90.50 870.50 Q 90.50 863.50 97.50 863.50 L 232.50 863.50 Q 239.50 863.50 239.50 870.50 L 239.50 889.50 L90.50 889.50 ' style='fill:url(#tableHeaderGradient7); stroke:none;' />
-<a xlink:href='#ag_handout_kits'><text x='120' y='877' class='tableTitle'>ag_handout_kits</text><title>Table ag.ag_handout_kits</title></a>
-  <use id='nn' x='92' y='897' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='92' y='896' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) </title></a>
-<a xlink:href='#kit_id'><text x='108' y='907'>kit_id</text><title>kit_id varchar&#040;9&#041; not null</title></a>
-  <a xlink:href='#password'><text x='108' y='922'>password</text><title>password varchar&#040;11&#041;</title></a>
-  <use id='nn' x='92' y='927' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='92' y='926' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) Unique Index  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='108' y='937'>barcode</text><title>barcode varchar&#040;9&#041; not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='228' y='926' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
-  <a xlink:href='#verification_code'><text x='108' y='952'>verification_code</text><title>verification_code varchar&#040;5&#041;</title></a>
-  <a xlink:href='#sample_barcode_file'><text x='108' y='967'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;13&#041;</title></a>
-  <a xlink:href='#swabs_per_kit'><text x='108' y='982'>swabs_per_kit</text><title>swabs_per_kit bigint</title></a>
-  <a xlink:href='#print_results'><text x='108' y='997'>print_results</text><title>print_results varchar&#040;1&#041; default &#039;n&#039;&#058;&#058;character varying</title></a>
+<rect class='table' x='45' y='413' width='135' height='135' rx='7' ry='7' />
+<path d='M 45.50 439.50 L 45.50 420.50 Q 45.50 413.50 52.50 413.50 L 172.50 413.50 Q 179.50 413.50 179.50 420.50 L 179.50 439.50 L45.50 439.50 ' style='fill:url(#tableHeaderGradient7); stroke:none;' />
+<a xlink:href='#ag_handout_kits'><text x='68' y='427' class='tableTitle'>ag_handout_kits</text><title>Table ag.ag_handout_kits</title></a>
+  <use id='nn' x='47' y='447' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='47' y='446' xlink:href='#pk'/><title>Primary Key  ( kit_id ) </title></a>
+<a xlink:href='#kit_id'><text x='63' y='457'>kit_id</text><title>kit_id varchar&#040;9&#041; not null</title></a>
+<a xlink:href='#kit_id'><use id='ref' x='168' y='446' xlink:href='#ref'/><title>Referred by handout_barcode ( kit_id ) </title></a>
+  <a xlink:href='#password'><text x='63' y='472'>password</text><title>password varchar&#040;11&#041;</title></a>
+  <a xlink:href='#verification_code'><text x='63' y='487'>verification_code</text><title>verification_code varchar&#040;5&#041;</title></a>
+  <a xlink:href='#swabs_per_kit'><text x='63' y='502'>swabs_per_kit</text><title>swabs_per_kit bigint</title></a>
+  <a xlink:href='#print_results'><text x='63' y='517'>print_results</text><title>print_results varchar&#040;1&#041; default &#039;n&#039;&#058;&#058;character varying</title></a>
+  <use id='nn' x='47' y='522' xlink:href='#nn'/><a xlink:href='#created_on'><text x='63' y='532'>created_on</text><title>created_on timestamp not null default current&#095;timestamp</title></a>
 
 </g></svg>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='ag_map_markers'>ag_map_markers</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='zipcode'>zipcode</a></td>
-		<td width='40%'> varchar&#040; 20 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='latitude'>latitude</a></td>
-		<td width='40%'> float8   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='longitude'>longitude</a></td>
-		<td width='40%'> float8   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='marker_color'>marker&#095;color</a></td>
-		<td width='40%'> varchar&#040; 10 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='order_by'>order&#095;by</a></td>
-		<td width='40%'> bigint   </td>
-		<td width='99%'>  </td>
-	</tr>
-</tbody>
-</table>
 
 <br/><br/>
 <table id='dbs' >
@@ -3267,6 +3251,88 @@ Referred by barcode_exceptions ( barcode ) </title></a>
 <br/><br/>
 <table id='dbs' >
 <thead>
+<tr><th colspan='3'><a name='ag_map_markers'>ag_map_markers</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='zipcode'>zipcode</a></td>
+		<td width='40%'> varchar&#040; 20 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='latitude'>latitude</a></td>
+		<td width='40%'> float8   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='longitude'>longitude</a></td>
+		<td width='40%'> float8   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='marker_color'>marker&#095;color</a></td>
+		<td width='40%'> varchar&#040; 10 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='order_by'>order&#095;by</a></td>
+		<td width='40%'> bigint   </td>
+		<td width='99%'>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='handout_barcode'>handout_barcode</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='kit_id'>kit&#095;id</a></td>
+		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='barcode'>barcode</a></td>
+		<td width='40%'> varchar&#040; 9 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='sample_barcode_file'>sample&#095;barcode&#095;file</a></td>
+		<td width='40%'> varchar&#040; 13 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>idx&#095;handout&#095;barcode primary key</td>
+		<td> ON kit&#095;id&#044; barcode</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;handout&#095;barcode&#095;0 </td>
+		<td> ON barcode</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;handout&#095;barcode&#095;1 </td>
+		<td> ON kit&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
+	<tr>
+		<td>fk_handout_barcode</td>
+		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_handout_barcode_0</td>
+		<td > ( kit&#095;id ) ref <a href='#ag&#095;handout&#095;kits'>ag&#095;handout&#095;kits</a> (kit&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
 <tr><th colspan='3'><a name='ag_handout_kits'>ag_handout_kits</a></th></tr>
 </thead>
 <tbody>
@@ -3281,18 +3347,8 @@ Referred by barcode_exceptions ( barcode ) </title></a>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
-		<td><a name='barcode'>barcode</a></td>
-		<td width='40%'> varchar&#040; 9 &#041;  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
 		<td><a name='verification_code'>verification&#095;code</a></td>
 		<td width='40%'> varchar&#040; 5 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='sample_barcode_file'>sample&#095;barcode&#095;file</a></td>
-		<td width='40%'> varchar&#040; 13 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -3305,19 +3361,14 @@ Referred by barcode_exceptions ( barcode ) </title></a>
 		<td width='40%'> varchar&#040; 1 &#041;   DEFO 'n'::character varying </td>
 		<td width='99%'>  </td>
 	</tr>
+	<tr>
+		<td><a name='created_on'>created&#095;on</a></td>
+		<td width='40%'> timestamp  NOT NULL  DEFO current_timestamp </td>
+		<td width='99%'>  </td>
+	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
 	<tr>		<td>pk&#095;ag&#095;handout&#095;kits primary key</td>
-		<td> ON kit&#095;id&#044; barcode</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;ag&#095;handout&#095;kits unique</td>
-		<td> ON barcode</td>
-		<td>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
-	<tr>
-		<td>fk_ag_handout_kits</td>
-		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
+		<td> ON kit&#095;id</td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/amgut/db/patches/0009.sql
+++ b/amgut/db/patches/0009.sql
@@ -2,11 +2,11 @@
 ALTER TABLE ag.ag_handout_kits ADD created_on timestamp DEFAULT current_timestamp NOT NULL;
 
 -- Create new ag_handout_barcodes table
-CREATE TABLE ag.ag_handout_barcodes ( 
+CREATE TABLE ag.ag_handout_barcodes (
 	kit_id               varchar  NOT NULL,
-	barcode              varchar(9)  NOT NULL UNIQUE,
+	barcode              varchar(9)  NOT NULL,
 	sample_barcode_file  varchar(13),
-	CONSTRAINT idx_ag_handout_barcodes PRIMARY KEY ( kit_id, barcode )
+	CONSTRAINT idx_ag_handout_barcodes PRIMARY KEY ( barcode )
  );
 
 CREATE INDEX idx_ag_handout_barcodes_0 ON ag.ag_handout_barcodes ( barcode );
@@ -19,7 +19,7 @@ ALTER TABLE ag.ag_handout_barcodes ADD CONSTRAINT fk_ag_handout_barcodes FOREIGN
 INSERT INTO ag.ag_handout_barcodes (kit_id, barcode, sample_barcode_file)
 SELECT kit_id, barcode, sample_barcode_file FROM ag.ag_handout_kits;
 
--- Delete duplicate handout rows and unneded columns from handouts table
+-- Delete duplicate handout rows and unneeded columns from handouts table
 DELETE FROM ag.ag_handout_kits WHERE barcode NOT IN (SELECT max(barcode) FROM ag.ag_handout_kits);
 
 ALTER TABLE ag.ag_handout_kits DROP COLUMN barcode, DROP COLUMN sample_barcode_file;

--- a/amgut/db/patches/0009.sql
+++ b/amgut/db/patches/0009.sql
@@ -4,7 +4,7 @@ ALTER TABLE ag.ag_handout_kits ADD created_on timestamp DEFAULT current_timestam
 -- Create new ag_handout_barcodes table
 CREATE TABLE ag.ag_handout_barcodes ( 
 	kit_id               varchar  NOT NULL,
-	barcode              varchar(9)  NOT NULL,
+	barcode              varchar(9)  NOT NULL UNIQUE,
 	sample_barcode_file  varchar(13),
 	CONSTRAINT idx_ag_handout_barcodes PRIMARY KEY ( kit_id, barcode )
  );

--- a/amgut/db/patches/0009.sql
+++ b/amgut/db/patches/0009.sql
@@ -9,8 +9,6 @@ CREATE TABLE ag.ag_handout_barcodes (
 	CONSTRAINT idx_ag_handout_barcodes PRIMARY KEY ( barcode )
  );
 
-CREATE INDEX idx_ag_handout_barcodes_0 ON ag.ag_handout_barcodes ( barcode );
-
 CREATE INDEX idx_ag_handout_barcodes_1 ON ag.ag_handout_barcodes ( kit_id );
 
 ALTER TABLE ag.ag_handout_barcodes ADD CONSTRAINT fk_ag_handout_barcodes FOREIGN KEY ( barcode ) REFERENCES ag.barcode( barcode );
@@ -20,7 +18,7 @@ INSERT INTO ag.ag_handout_barcodes (kit_id, barcode, sample_barcode_file)
 SELECT kit_id, barcode, sample_barcode_file FROM ag.ag_handout_kits;
 
 -- Delete duplicate handout rows and unneeded columns from handouts table
-DELETE FROM ag.ag_handout_kits WHERE barcode NOT IN (SELECT max(barcode) FROM ag.ag_handout_kits);
+DELETE FROM ag.ag_handout_kits WHERE barcode NOT IN (SELECT max(barcode) FROM ag.ag_handout_kits GROUP BY kit_id);
 
 ALTER TABLE ag.ag_handout_kits DROP COLUMN barcode, DROP COLUMN sample_barcode_file;
 

--- a/amgut/db/patches/0009.sql
+++ b/amgut/db/patches/0009.sql
@@ -25,5 +25,5 @@ DELETE FROM ag.ag_handout_kits WHERE barcode NOT IN (SELECT max(barcode) FROM ag
 ALTER TABLE ag.ag_handout_kits DROP COLUMN barcode, DROP COLUMN sample_barcode_file;
 
 -- Add unique constraint to the kit_id column and the foreign key for new table
-ALTER TABLE ag.ag_handout_kits ADD UNIQUE (kit_id);
+ALTER TABLE ag.ag_handout_kits ADD PRIMARY KEY (kit_id);
 ALTER TABLE ag.handout_barcode ADD CONSTRAINT fk_handout_barcode_0 FOREIGN KEY ( kit_id ) REFERENCES ag.ag_handout_kits( kit_id ) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/amgut/db/patches/0009.sql
+++ b/amgut/db/patches/0009.sql
@@ -1,0 +1,29 @@
+-- Add created_on timestamp for handout kits
+ALTER TABLE ag.ag_handout_kits ADD created_on timestamp DEFAULT current_timestamp NOT NULL;
+
+-- Create new handout_barcode table
+CREATE TABLE ag.handout_barcode ( 
+	kit_id               varchar  NOT NULL,
+	barcode              varchar(9)  NOT NULL,
+	sample_barcode_file  varchar(13),
+	CONSTRAINT idx_handout_barcode PRIMARY KEY ( kit_id, barcode )
+ );
+
+CREATE INDEX idx_handout_barcode_0 ON ag.handout_barcode ( barcode );
+
+CREATE INDEX idx_handout_barcode_1 ON ag.handout_barcode ( kit_id );
+
+ALTER TABLE ag.handout_barcode ADD CONSTRAINT fk_handout_barcode FOREIGN KEY ( barcode ) REFERENCES ag.barcode( barcode );
+
+-- Copy needed data to new table
+INSERT INTO ag.handout_barcode (kit_id, barcode, sample_barcode_file)
+SELECT kit_id, barcode, sample_barcode_file FROM ag.ag_handout_kits;
+
+-- Delete duplicate handout rows and unneded columns from handouts table
+DELETE FROM ag.ag_handout_kits WHERE barcode NOT IN (SELECT max(barcode) FROM ag.ag_handout_kits);
+
+ALTER TABLE ag.ag_handout_kits DROP COLUMN barcode, DROP COLUMN sample_barcode_file;
+
+-- Add unique constraint to the kit_id column and the foreign key for new table
+ALTER TABLE ag.ag_handout_kits ADD UNIQUE (kit_id);
+ALTER TABLE ag.handout_barcode ADD CONSTRAINT fk_handout_barcode_0 FOREIGN KEY ( kit_id ) REFERENCES ag.ag_handout_kits( kit_id ) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/amgut/db/patches/0009.sql
+++ b/amgut/db/patches/0009.sql
@@ -1,22 +1,22 @@
 -- Add created_on timestamp for handout kits
 ALTER TABLE ag.ag_handout_kits ADD created_on timestamp DEFAULT current_timestamp NOT NULL;
 
--- Create new handout_barcode table
-CREATE TABLE ag.handout_barcode ( 
+-- Create new ag_handout_barcodes table
+CREATE TABLE ag.ag_handout_barcodes ( 
 	kit_id               varchar  NOT NULL,
 	barcode              varchar(9)  NOT NULL,
 	sample_barcode_file  varchar(13),
-	CONSTRAINT idx_handout_barcode PRIMARY KEY ( kit_id, barcode )
+	CONSTRAINT idx_ag_handout_barcodes PRIMARY KEY ( kit_id, barcode )
  );
 
-CREATE INDEX idx_handout_barcode_0 ON ag.handout_barcode ( barcode );
+CREATE INDEX idx_ag_handout_barcodes_0 ON ag.ag_handout_barcodes ( barcode );
 
-CREATE INDEX idx_handout_barcode_1 ON ag.handout_barcode ( kit_id );
+CREATE INDEX idx_ag_handout_barcodes_1 ON ag.ag_handout_barcodes ( kit_id );
 
-ALTER TABLE ag.handout_barcode ADD CONSTRAINT fk_handout_barcode FOREIGN KEY ( barcode ) REFERENCES ag.barcode( barcode );
+ALTER TABLE ag.ag_handout_barcodes ADD CONSTRAINT fk_ag_handout_barcodes FOREIGN KEY ( barcode ) REFERENCES ag.barcode( barcode );
 
 -- Copy needed data to new table
-INSERT INTO ag.handout_barcode (kit_id, barcode, sample_barcode_file)
+INSERT INTO ag.ag_handout_barcodes (kit_id, barcode, sample_barcode_file)
 SELECT kit_id, barcode, sample_barcode_file FROM ag.ag_handout_kits;
 
 -- Delete duplicate handout rows and unneded columns from handouts table
@@ -26,4 +26,4 @@ ALTER TABLE ag.ag_handout_kits DROP COLUMN barcode, DROP COLUMN sample_barcode_f
 
 -- Add unique constraint to the kit_id column and the foreign key for new table
 ALTER TABLE ag.ag_handout_kits ADD PRIMARY KEY (kit_id);
-ALTER TABLE ag.handout_barcode ADD CONSTRAINT fk_handout_barcode_0 FOREIGN KEY ( kit_id ) REFERENCES ag.ag_handout_kits( kit_id ) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE ag.ag_handout_barcodes ADD CONSTRAINT fk_ag_handout_barcodes_0 FOREIGN KEY ( kit_id ) REFERENCES ag.ag_handout_kits( kit_id ) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/amgut/db/populate_test.sql
+++ b/amgut/db/populate_test.sql
@@ -79,7 +79,7 @@ insert into project_barcode (project_id, barcode) values (1, '000010860'), (1, '
             'MAKE SURE THIS IS BEING PASSED','12:05 PM','','','','','','','','','','');
 insert into ag_handout_kits (kit_id, password, verification_code, swabs_per_kit, print_results)
     values('test_ha', '$2a$12$GfYI6sxlVGTamDJ3FEQzMuQ46eSV6YJ.DxUxiZvKJaAn1NJtTDtFS', '5678', '3', 'n');
-insert into handout_barcode (kit_id, barcode)
+insert into ag_handout_barcodes (kit_id, barcode)
     values ('test_ha', '000000002'),('test_ha', '000000003'),('test_ha', '000000004');
 insert into ag_participant_exceptions (ag_login_id, participant_name)
     values ('d8592c74-7da1-2135-e040-8a80115d6401', 'exception');

--- a/amgut/db/populate_test.sql
+++ b/amgut/db/populate_test.sql
@@ -77,10 +77,10 @@ insert into project_barcode (project_id, barcode) values (1, '000010860'), (1, '
             '12/02/2013','foo','06:20 AM','','','N','N','N','','None','Y','N','N'),
         ('ded369ec-7d0f-4d8c-e040-8a80115d6742','d8592c74-7da2-2135-e040-8a80115d6401','000006616',19,'000006616.jpg','','Nasal mucus','08/12/2014',
             'MAKE SURE THIS IS BEING PASSED','12:05 PM','','','','','','','','','','');
-insert into ag_handout_kits (kit_id, password, barcode, verification_code, swabs_per_kit, print_results)
-    values('test_ha', '$2a$12$GfYI6sxlVGTamDJ3FEQzMuQ46eSV6YJ.DxUxiZvKJaAn1NJtTDtFS', '000000002', '5678', '3', 'n'),
-          ('test_ha', '$2a$12$GfYI6sxlVGTamDJ3FEQzMuQ46eSV6YJ.DxUxiZvKJaAn1NJtTDtFS', '000000003', '5678', '3', 'n'),
-          ('test_ha', '$2a$12$GfYI6sxlVGTamDJ3FEQzMuQ46eSV6YJ.DxUxiZvKJaAn1NJtTDtFS', '000000004', '5678', '3', 'n');
+insert into ag_handout_kits (kit_id, password, verification_code, swabs_per_kit, print_results)
+    values('test_ha', '$2a$12$GfYI6sxlVGTamDJ3FEQzMuQ46eSV6YJ.DxUxiZvKJaAn1NJtTDtFS', '5678', '3', 'n');
+insert into handout_barcode (kit_id, barcode)
+    values ('test_ha', '000000002'),('test_ha', '000000003'),('test_ha', '000000004');
 insert into ag_participant_exceptions (ag_login_id, participant_name)
     values ('d8592c74-7da1-2135-e040-8a80115d6401', 'exception');
 insert into ag_login_surveys (ag_login_id, survey_id, participant_name)

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -260,7 +260,7 @@ class AGDataAccess(object):
         sql = """SELECT * FROM ag.ag_handout_kits
                  JOIN (SELECT
                     kit_id, array_agg(barcode ORDER BY barcode) AS barcodes,
-                    sample_barcode_file FROM ag.handout_barcode
+                    sample_barcode_file FROM ag.ag_handout_barcodes
                     GROUP BY kit_id, sample_barcode_file) AS hb
                  USING (kit_id)
                  WHERE kit_id = %s"""
@@ -423,7 +423,7 @@ class AGDataAccess(object):
                     FROM ag_handout_kits WHERE kit_id = %s LIMIT 1
                 RETURNING ag_kit_id INTO k_id;
                 FOR bc IN
-                    SELECT barcode FROM handout_barcode WHERE kit_id = %s
+                    SELECT barcode FROM ag_handout_barcodes WHERE kit_id = %s
                 LOOP
                     INSERT  INTO ag_kit_barcodes
                         (ag_kit_id, barcode, sample_barcode_file)
@@ -1228,7 +1228,7 @@ class AGDataAccess(object):
         return [dict(zip(col_names, row)) for row in results]
 
     def get_barcodes_from_handout_kit(self, supplied_kit_id):
-        sql = "select barcode from handout_barcode where kit_id = %s"
+        sql = "select barcode from ag_handout_barcodes where kit_id = %s"
         cursor = self.get_cursor()
         cursor.execute(sql, [supplied_kit_id])
         results = cursor.fetchall()
@@ -1328,7 +1328,7 @@ class AGDataAccess(object):
         sql = """SELECT kit_id, password, barcode, verification_code
                  FROM ag_handout_kits
                  JOIN (SELECT kit_id, barcode, sample_barcode_file
-                    FROM ag.handout_barcode
+                    FROM ag.ag_handout_barcodes
                     GROUP BY kit_id, barcode) AS hb USING (kit_id)
                  WHERE kit_id LIKE %s or barcode LIKE %s"""
         cursor = self.get_cursor()

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -950,7 +950,7 @@ class AGDataAccess(object):
 
     def handoutCheck(self, username, password):
         cursor = self.get_cursor()
-        cursor.execute("""SELECT DISTINCT (password)
+        cursor.execute("""SELECT password
                           FROM ag.ag_handout_kits
                           WHERE kit_id=%s""", [username])
         to_check = cursor.fetchone()

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -1325,12 +1325,11 @@ class AGDataAccess(object):
         return results
 
     def search_handout_kits(self, term):
-        sql = """SELECT kit_id, password, barcodes, verification_code
+        sql = """SELECT kit_id, password, barcode, verification_code
                  FROM ag_handout_kits
-                 JOIN (SELECT
-                    kit_id, array_agg(barcode ORDER BY barcode) AS barcodes
+                 JOIN (SELECT kit_id, barcode, sample_barcode_file
                     FROM ag.handout_barcode
-                    GROUP BY kit_id, sample_barcode_file) AS hb USING (kit_id)
+                    GROUP BY kit_id, barcode) AS hb USING (kit_id)
                  WHERE kit_id LIKE %s or barcode LIKE %s"""
         cursor = self.get_cursor()
         liketerm = '%%' + term + '%%'


### PR DESCRIPTION
This breaks up the handout kits into two tables: one for handout kit info and one for barcodes attached to the handout. This fixes the issue we've seen previously, where each row in the `ag_handout_kits` table for a given kit is exactly the same except for the barcode. this breakout means that each kit now has a single entry in that table, and the deletion of a kit from that table cascades down and deletes the barcodes from the second table. This is a much cleaner representation, as it allows us to properly represent kits with multiple barcodes.