### PR TITLE
Barcodes in own schema

### DIFF
--- a/amgut/db/ag.dbs
+++ b/amgut/db/ag.dbs
@@ -33,7 +33,7 @@
 		<table name="ag_consent" >
 			<column name="ag_login_id" type="uuid" jt="1111" mandatory="y" />
 			<column name="participant_name" type="varchar" length="200" jt="12" mandatory="y" />
-			<column name="participant_email" type="varchar" jt="12" mandatory="y" />
+			<column name="participant_email" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<column name="is_juvenile" type="bool" length="10" jt="-7" />
 			<column name="parent_1_name" type="varchar" length="200" jt="12" />
 			<column name="parent_2_name" type="varchar" length="200" jt="12" />
@@ -41,8 +41,8 @@
 			<column name="parent_2_code" type="varchar" length="200" jt="12" />
 			<column name="deceased_parent" type="varchar" length="10" jt="12" />
 			<column name="date_signed" type="date" jt="91" />
-			<column name="assent_obtainer" type="varchar" jt="12" />
-			<column name="age_range" type="varchar" jt="12" />
+			<column name="assent_obtainer" type="varchar" length="2147483647" jt="12" />
+			<column name="age_range" type="varchar" length="2147483647" jt="12" />
 			<index name="pk_american_gut_consent" unique="PRIMARY_KEY" >
 				<column name="ag_login_id" />
 				<column name="participant_name" />
@@ -56,7 +56,7 @@
 		</table>
 		<table name="ag_handout_kits" >
 			<column name="kit_id" type="varchar" length="9" jt="12" mandatory="y" />
-			<column name="password" type="varchar" length="11" jt="12" />
+			<column name="password" type="varchar" length="60" jt="12" />
 			<column name="verification_code" type="varchar" length="5" jt="12" />
 			<column name="swabs_per_kit" type="bigint" length="19" jt="-5" />
 			<column name="print_results" type="varchar" length="1" jt="12" >
@@ -65,7 +65,7 @@
 			<column name="created_on" type="timestamp" jt="93" mandatory="y" >
 				<defo>current_timestamp</defo>
 			</column>
-			<index name="pk_ag_handout_kits" unique="PRIMARY_KEY" >
+			<index name="ag_handout_kits_pkey" unique="PRIMARY_KEY" >
 				<column name="kit_id" />
 			</index>
 		</table>
@@ -205,11 +205,11 @@
 		</table>
 		<table name="ag_kit" >
 			<column name="ag_kit_id" type="uuid" length="2147483647" jt="1111" mandatory="y" >
-				<defo>uuid_generate_v4()</defo>
+				<defo>ag.uuid_generate_v4()</defo>
 			</column>
 			<column name="ag_login_id" type="uuid" length="2147483647" jt="1111" mandatory="y" />
 			<column name="supplied_kit_id" type="varchar" length="50" jt="12" mandatory="y" />
-			<column name="kit_password" type="varchar" length="50" jt="12" />
+			<column name="kit_password" type="varchar" length="60" jt="12" />
 			<column name="swabs_per_kit" type="bigint" length="19" jt="-5" mandatory="y" />
 			<column name="kit_verification_code" type="varchar" length="50" jt="12" />
 			<column name="kit_verified" type="char" length="1" jt="1" >
@@ -222,6 +222,9 @@
 			<column name="pass_reset_time" type="timestamp" length="29" decimal="6" jt="93" />
 			<column name="print_results" type="varchar" length="1" jt="12" >
 				<defo>&#039;n&#039;::character varying</defo>
+			</column>
+			<column name="open_humans_token" type="varchar" length="64" jt="12" >
+				<comment><![CDATA[The Open Humans access token corresponding to the Open Humans user that has authorized data sharing with this kit.]]></comment>
 			</column>
 			<index name="ag_kit_pkey" unique="PRIMARY_KEY" >
 				<column name="ag_kit_id" />
@@ -238,11 +241,11 @@
 		</table>
 		<table name="ag_kit_barcodes" >
 			<column name="ag_kit_barcode_id" type="uuid" length="2147483647" jt="1111" mandatory="y" >
-				<defo>uuid_generate_v4()</defo>
+				<defo>ag.uuid_generate_v4()</defo>
 			</column>
 			<column name="ag_kit_id" type="uuid" length="2147483647" jt="1111" />
-			<column name="barcode" type="varchar" jt="12" mandatory="y" />
-			<column name="survey_id" type="varchar" jt="12" />
+			<column name="barcode" type="varchar" length="2147483647" jt="12" mandatory="y" />
+			<column name="survey_id" type="varchar" length="2147483647" jt="12" />
 			<column name="sample_barcode_file" type="varchar" length="500" jt="12" />
 			<column name="sample_barcode_file_md5" type="varchar" length="50" jt="12" />
 			<column name="site_sampled" type="varchar" length="200" jt="12" />
@@ -274,16 +277,16 @@
 			<fk name="fk_ag_kit_barcodes" to_schema="ag" to_table="ag_kit" >
 				<fk_column name="ag_kit_id" pk="ag_kit_id" />
 			</fk>
-			<fk name="fk_ag_kit_barcodes_0" to_schema="ag" to_table="barcode" >
-				<fk_column name="barcode" pk="barcode" />
-			</fk>
 			<fk name="fk_ag_kit_barcodes_1" to_schema="ag" to_table="ag_login_surveys" >
 				<fk_column name="survey_id" pk="survey_id" />
+			</fk>
+			<fk name="fk_ag_kit_barcodes_barcode" to_schema="barcodes" to_table="barcode" >
+				<fk_column name="barcode" pk="barcode" />
 			</fk>
 		</table>
 		<table name="ag_login" >
 			<column name="ag_login_id" type="uuid" length="2147483647" jt="1111" mandatory="y" >
-				<defo>uuid_generate_v4()</defo>
+				<defo>ag.uuid_generate_v4()</defo>
 			</column>
 			<column name="email" type="varchar" length="100" jt="12" />
 			<column name="name" type="varchar" length="200" jt="12" />
@@ -302,8 +305,8 @@
 		</table>
 		<table name="ag_login_surveys" >
 			<column name="ag_login_id" type="uuid" jt="1111" mandatory="y" />
-			<column name="survey_id" type="varchar" jt="12" mandatory="y" />
-			<column name="participant_name" type="varchar" jt="12" />
+			<column name="survey_id" type="varchar" length="2147483647" jt="12" mandatory="y" />
+			<column name="participant_name" type="varchar" length="2147483647" jt="12" />
 			<column name="vioscreen_status" type="integer" jt="4" />
 			<index name="pk_ag_login_surveys" unique="PRIMARY_KEY" >
 				<column name="survey_id" />
@@ -345,7 +348,7 @@
 			<column name="participant_name" type="varchar" length="200" jt="12" mandatory="y" />
 			<column name="question" type="varchar" length="100" jt="12" mandatory="y" />
 			<column name="ag_survery_answer_id" type="uuid" length="2147483647" jt="1111" >
-				<defo>uuid_generate_v4()</defo>
+				<defo>ag.uuid_generate_v4()</defo>
 			</column>
 			<column name="answer" type="varchar" length="4000" jt="12" />
 			<index name="ag_survey_answer_pkey" unique="PRIMARY_KEY" >
@@ -383,30 +386,6 @@
 				<column name="participant_name" />
 			</index>
 		</table>
-		<table name="barcode" >
-			<column name="barcode" type="varchar" jt="12" mandatory="y" />
-			<column name="create_date_time" type="timestamp" length="29" decimal="6" jt="93" >
-				<defo>(&#039;now&#039;::text)::timestamp without time zone</defo>
-			</column>
-			<column name="status" type="varchar" length="100" jt="12" />
-			<column name="scan_date" type="varchar" length="20" jt="12" />
-			<column name="sample_postmark_date" type="varchar" length="20" jt="12" />
-			<column name="biomass_remaining" type="varchar" length="1" jt="12" />
-			<column name="sequencing_status" type="varchar" length="20" jt="12" />
-			<column name="obsolete" type="varchar" length="1" jt="12" />
-			<index name="barcode_pkey" unique="PRIMARY_KEY" >
-				<column name="barcode" />
-			</index>
-		</table>
-		<table name="barcode_exceptions" >
-			<column name="barcode" type="varchar" length="100" jt="12" mandatory="y" />
-			<index name="pk_barcode_exceptions" unique="PRIMARY_KEY" >
-				<column name="barcode" />
-			</index>
-			<fk name="fk_barcode_exceptions" to_schema="ag" to_table="barcode" >
-				<fk_column name="barcode" pk="barcode" />
-			</fk>
-		</table>
 		<table name="controlled_vocab_values" >
 			<column name="vocab_value_id" type="bigint" length="19" jt="-5" mandatory="y" />
 			<column name="controlled_vocab_id" type="bigint" length="19" jt="-5" mandatory="y" />
@@ -429,18 +408,18 @@
 		</table>
 		<table name="external_survey" >
 			<column name="external_survey_id" type="bigserial" jt="-5" mandatory="y" />
-			<column name="external_survey" type="varchar" jt="12" mandatory="y" />
-			<column name="external_survey_description" type="varchar" jt="12" />
+			<column name="external_survey" type="varchar" length="2147483647" jt="12" mandatory="y" />
+			<column name="external_survey_description" type="varchar" length="2147483647" jt="12" />
 			<index name="pk_external_surveys" unique="PRIMARY_KEY" >
 				<column name="external_survey_id" />
 			</index>
 		</table>
 		<table name="external_survey_answers" >
 			<comment>This stores answers to third party surveys in JSON format, keyed to the original survey ID</comment>
-			<column name="survey_id" type="varchar" jt="12" mandatory="y" />
+			<column name="survey_id" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<column name="external_survey_id" type="bigint" jt="-5" mandatory="y" />
 			<column name="pulldown_date" type="date" jt="91" mandatory="y" />
-			<column name="answers" type="varchar" jt="12" mandatory="y" />
+			<column name="answers" type="json" length="2147483647" jt="1111" mandatory="y" />
 			<index name="pk_third_party_surveys" unique="PRIMARY_KEY" >
 				<column name="survey_id" />
 			</index>
@@ -480,9 +459,9 @@
 			</fk>
 		</table>
 		<table name="handout_barcode" >
-			<column name="kit_id" type="varchar" jt="12" mandatory="y" />
+			<column name="kit_id" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<column name="barcode" type="varchar" length="9" jt="12" mandatory="y" />
-			<column name="sample_barcode_file" type="varchar" length="13" jt="12" mandatory="y" />
+			<column name="sample_barcode_file" type="varchar" length="13" jt="12" />
 			<index name="idx_handout_barcode" unique="PRIMARY_KEY" >
 				<column name="kit_id" />
 				<column name="barcode" />
@@ -493,19 +472,19 @@
 			<index name="idx_handout_barcode_1" unique="NORMAL" >
 				<column name="kit_id" />
 			</index>
-			<fk name="fk_handout_barcode" to_schema="ag" to_table="barcode" >
-				<fk_column name="barcode" pk="barcode" />
-			</fk>
 			<fk name="fk_handout_barcode_0" to_schema="ag" to_table="ag_handout_kits" delete_action="cascade" update_action="cascade" >
 				<fk_column name="kit_id" pk="kit_id" />
+			</fk>
+			<fk name="fk_handout_barcode_barcode" to_schema="barcodes" to_table="barcode" >
+				<fk_column name="barcode" pk="barcode" />
 			</fk>
 		</table>
 		<table name="iso_country_lookup" >
 			<comment>ISO standard codes for countries</comment>
-			<column name="iso_code" type="varchar" jt="12" mandatory="y" >
+			<column name="iso_code" type="varchar" length="2147483647" jt="12" mandatory="y" >
 				<comment><![CDATA[The ISO code for the country]]></comment>
 			</column>
-			<column name="country" type="varchar" jt="12" mandatory="y" />
+			<column name="country" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<index name="pk_iso_country_lookup" unique="PRIMARY_KEY" >
 				<column name="iso_code" />
 			</index>
@@ -516,54 +495,9 @@
 				<fk_column name="country" pk="american" />
 			</fk>
 		</table>
-		<table name="plate" >
-			<column name="plate_id" type="bigint" length="19" jt="-5" mandatory="y" />
-			<column name="plate" type="varchar" length="50" jt="12" />
-			<column name="sequence_date" type="varchar" length="20" jt="12" />
-			<index name="plate_pkey" unique="PRIMARY_KEY" >
-				<column name="plate_id" />
-			</index>
-		</table>
-		<table name="plate_barcode" >
-			<column name="plate_id" type="bigint" length="19" jt="-5" mandatory="y" />
-			<column name="barcode" type="varchar" jt="12" mandatory="y" />
-			<index name="idx_plate_barcode" unique="NORMAL" >
-				<column name="barcode" />
-			</index>
-			<index name="idx_plate_barcode_0" unique="NORMAL" >
-				<column name="plate_id" />
-			</index>
-			<fk name="fk_plate_barcode" to_schema="ag" to_table="barcode" >
-				<fk_column name="barcode" pk="barcode" />
-			</fk>
-			<fk name="fk_plate_barcode_0" to_schema="ag" to_table="plate" >
-				<fk_column name="plate_id" pk="plate_id" />
-			</fk>
-		</table>
-		<table name="project" >
-			<column name="project_id" type="bigint" length="19" jt="-5" mandatory="y" />
-			<column name="project" type="varchar" length="1000" jt="12" />
-			<index name="project_pkey" unique="PRIMARY_KEY" >
-				<column name="project_id" />
-			</index>
-		</table>
-		<table name="project_barcode" >
-			<column name="project_id" type="bigint" length="19" jt="-5" mandatory="y" />
-			<column name="barcode" type="char" length="9" jt="1" mandatory="y" />
-			<index name="project_barcode_pkey" unique="PRIMARY_KEY" >
-				<column name="project_id" />
-				<column name="barcode" />
-			</index>
-			<fk name="fk_pb_to_barcode" to_schema="ag" to_table="barcode" >
-				<fk_column name="barcode" pk="barcode" />
-			</fk>
-			<fk name="fk_pb_to_project" to_schema="ag" to_table="project" >
-				<fk_column name="project_id" pk="project_id" />
-			</fk>
-		</table>
 		<table name="promoted_survey_ids" >
 			<comment>Keeps track of the survey_ids that correspond to surveys that were ported from first questionnaire to the second</comment>
-			<column name="survey_id" type="varchar" jt="12" mandatory="y" />
+			<column name="survey_id" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<index name="pk_promoted_survey_ids" unique="PRIMARY_KEY" >
 				<column name="survey_id" />
 			</index>
@@ -571,15 +505,23 @@
 				<fk_column name="survey_id" pk="survey_id" />
 			</fk>
 		</table>
+		<table name="settings" >
+			<column name="test_environment" type="varchar" length="2147483647" jt="12" />
+			<column name="base_data_dir" type="varchar" length="2147483647" jt="12" />
+			<column name="locale" type="varchar" length="2147483647" jt="12" />
+			<column name="current_patch" type="varchar" length="2147483647" jt="12" mandatory="y" >
+				<defo>&#039;unpatched&#039;::character varying</defo>
+			</column>
+		</table>
 		<table name="survey_answers" >
 			<comment>Stores answers to questions of type SINGLE and MULTIPLE</comment>
-			<column name="survey_id" type="varchar" jt="12" mandatory="y" >
+			<column name="survey_id" type="varchar" length="2147483647" jt="12" mandatory="y" >
 				<comment><![CDATA[The unique identifier for the survey]]></comment>
 			</column>
 			<column name="survey_question_id" type="bigint" jt="-5" mandatory="y" >
 				<comment><![CDATA[The question being answered]]></comment>
 			</column>
-			<column name="response" type="varchar" jt="12" mandatory="y" >
+			<column name="response" type="varchar" length="2147483647" jt="12" mandatory="y" >
 				<comment><![CDATA[The answer the question being asked]]></comment>
 			</column>
 			<index name="pk_survey_answers" unique="PRIMARY_KEY" >
@@ -604,9 +546,9 @@
 		</table>
 		<table name="survey_answers_other" >
 			<comment>Survey answers for which there are no corresponding foreign keys</comment>
-			<column name="survey_id" type="varchar" jt="12" mandatory="y" />
+			<column name="survey_id" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<column name="survey_question_id" type="bigint" jt="-5" mandatory="y" />
-			<column name="response" type="varchar" jt="12" mandatory="y" />
+			<column name="response" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<index name="pk_survey_answers_other" unique="PRIMARY_KEY" >
 				<column name="survey_id" />
 				<column name="survey_question_id" />
@@ -628,10 +570,10 @@
 			<column name="group_order" type="integer" jt="4" mandatory="y" >
 				<comment><![CDATA[The order that this group will be displayed in]]></comment>
 			</column>
-			<column name="american" type="varchar" jt="12" >
+			<column name="american" type="varchar" length="2147483647" jt="12" >
 				<comment><![CDATA[The american english version of the question group's name]]></comment>
 			</column>
-			<column name="british" type="varchar" jt="12" />
+			<column name="british" type="varchar" length="2147483647" jt="12" />
 			<index name="idx_human_survey_question_group" unique="UNIQUE" >
 				<column name="american" />
 			</index>
@@ -648,13 +590,12 @@
 				<comment><![CDATA[The unique question ID]]></comment>
 			</column>
 			<column name="question_shortname" type="varchar" length="100" jt="12" mandatory="y" >
-				<defo>&#039;TODO&#039;</defo>
 				<comment><![CDATA[A QIIME mapping file-compatible header that describes the question and can be used for metadata pulldown]]></comment>
 			</column>
-			<column name="american" type="varchar" jt="12" >
+			<column name="american" type="varchar" length="2147483647" jt="12" >
 				<comment><![CDATA[The american english version of the question]]></comment>
 			</column>
-			<column name="british" type="varchar" jt="12" >
+			<column name="british" type="varchar" length="2147483647" jt="12" >
 				<comment><![CDATA[The british english version of the question]]></comment>
 			</column>
 			<index name="pk_human_survey_question" unique="PRIMARY_KEY" >
@@ -673,8 +614,8 @@
 		<table name="survey_question_response" >
 			<comment>Maps questions to responses</comment>
 			<column name="survey_question_id" type="bigint" jt="-5" mandatory="y" />
-			<column name="response" type="varchar" jt="12" mandatory="y" />
-			<column name="display_index" type="serial" jt="4" >
+			<column name="response" type="varchar" length="2147483647" jt="12" mandatory="y" />
+			<column name="display_index" type="serial" length="10" jt="4" mandatory="y" >
 				<comment><![CDATA[The display order of this response]]></comment>
 			</column>
 			<index name="pk_question_response" unique="PRIMARY_KEY" >
@@ -695,7 +636,7 @@
 		<table name="survey_question_response_type" >
 			<comment>Stores the type of response for each question</comment>
 			<column name="survey_question_id" type="bigint" jt="-5" />
-			<column name="survey_response_type" type="varchar" jt="12" mandatory="y" />
+			<column name="survey_response_type" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<index name="idx_human_survey_response_type" unique="NORMAL" >
 				<column name="survey_question_id" />
 			</index>
@@ -714,7 +655,7 @@
 			<column name="survey_question_id" type="bigint" jt="-5" >
 				<comment><![CDATA[The ID of the question that is triggered]]></comment>
 			</column>
-			<column name="triggering_response" type="varchar" jt="12" >
+			<column name="triggering_response" type="varchar" length="2147483647" jt="12" >
 				<comment><![CDATA[The response to the question that will cause the appearance of the triggered_question]]></comment>
 			</column>
 			<column name="triggered_question" type="bigint" jt="-5" >
@@ -747,8 +688,8 @@
 		</table>
 		<table name="survey_response" >
 			<comment>Stores every possible predictable response on the human survey</comment>
-			<column name="american" type="varchar" jt="12" mandatory="y" />
-			<column name="british" type="varchar" jt="12" />
+			<column name="american" type="varchar" length="2147483647" jt="12" mandatory="y" />
+			<column name="british" type="varchar" length="2147483647" jt="12" />
 			<index name="pk_human_survey_response" unique="PRIMARY_KEY" >
 				<column name="american" />
 			</index>
@@ -758,7 +699,7 @@
 		</table>
 		<table name="survey_response_types" >
 			<comment>Stores every possible type of response.  The response type will be processed in python to determine how the question is represented in the interface.</comment>
-			<column name="survey_response_type" type="varchar" jt="12" mandatory="y" />
+			<column name="survey_response_type" type="varchar" length="2147483647" jt="12" mandatory="y" />
 			<index name="pk_human_survey_response_types" unique="PRIMARY_KEY" >
 				<column name="survey_response_type" />
 			</index>
@@ -778,10 +719,10 @@
 			</fk>
 		</table>
 		<table name="zipcodes" >
-			<column name="zipcode" type="varchar" jt="12" mandatory="y" />
-			<column name="state" type="varchar" jt="12" />
-			<column name="fips_regions" type="varchar" jt="12" />
-			<column name="city" type="varchar" jt="12" />
+			<column name="zipcode" type="varchar" length="2147483647" jt="12" mandatory="y" />
+			<column name="state" type="varchar" length="2147483647" jt="12" />
+			<column name="fips_regions" type="varchar" length="2147483647" jt="12" />
+			<column name="city" type="varchar" length="2147483647" jt="12" />
 			<column name="latitude" type="float8" jt="6" />
 			<column name="longitude" type="float8" jt="6" />
 			<column name="elevation" type="float8" jt="6" />
@@ -789,6 +730,130 @@
 			<index name="zipcodes_pkey" unique="PRIMARY_KEY" >
 				<column name="zipcode" />
 			</index>
+		</table>
+		<sequence name="external_survey_external_survey_id_seq" start="1" />
+		<sequence name="survey_question_response_display_index_seq" start="1" />
+		<function name="ag_add_animal_participant" id="Function7910859" isSystem="false" />
+		<function name="ag_add_participant" id="Function7910859" isSystem="false" />
+		<function name="ag_authenticate_user" id="Function7910859" isSystem="false" />
+		<function name="ag_available_barcodes" id="Function7910860" isSystem="false" />
+		<function name="ag_check_barcode_status" id="Function7910860" isSystem="false" />
+		<function name="ag_delete_participant" id="Function7910860" isSystem="false" />
+		<function name="ag_delete_sample" id="Function7910860" isSystem="false" />
+		<function name="ag_delete_survey_answer" id="Function7910860" isSystem="false" />
+		<function name="ag_get_animal_participants" id="Function7910860" isSystem="false" />
+		<function name="ag_get_barcode_details" id="Function7910860" isSystem="false" />
+		<function name="ag_get_barcode_md_animal" id="Function7910860" isSystem="false" />
+		<function name="ag_get_barcode_metadata" id="Function7910860" isSystem="false" />
+		<function name="ag_get_barcodes" id="Function7910860" isSystem="false" />
+		<function name="ag_get_barcodes_by_kit" id="Function7910860" isSystem="false" />
+		<function name="ag_get_barcodes_by_login" id="Function7910860" isSystem="false" />
+		<function name="ag_get_environmental_samples" id="Function7910860" isSystem="false" />
+		<function name="ag_get_human_participants" id="Function7910860" isSystem="false" />
+		<function name="ag_get_kit_details" id="Function7910860" isSystem="false" />
+		<function name="ag_get_kit_id_by_email" id="Function7910860" isSystem="false" />
+		<function name="ag_get_kits_by_login" id="Function7910860" isSystem="false" />
+		<function name="ag_get_logins" id="Function7910860" isSystem="false" />
+		<function name="ag_get_map_markers" id="Function7910860" isSystem="false" />
+		<function name="ag_get_next_barcode" id="Function7910860" isSystem="false" />
+		<function name="ag_get_participant_exceptions" id="Function7910860" isSystem="false" />
+		<function name="ag_get_participant_samples" id="Function7910861" isSystem="false" />
+		<function name="ag_get_print_results" id="Function7910861" isSystem="false" />
+		<function name="ag_get_survey_details" id="Function7910861" isSystem="false" />
+		<function name="ag_insert_barcode" id="Function7910861" isSystem="false" />
+		<function name="ag_insert_kit" id="Function7910861" isSystem="false" />
+		<function name="ag_insert_login" id="Function7910861" isSystem="false" />
+		<function name="ag_insert_participant_exception" id="Function7910861" isSystem="false" />
+		<function name="ag_insert_survey_answer" id="Function7910861" isSystem="false" />
+		<function name="ag_is_handout" id="Function7910861" isSystem="false" />
+		<function name="ag_log_participant_sample" id="Function7910861" isSystem="false" />
+		<function name="ag_reassign_barcode" id="Function7910861" isSystem="false" />
+		<function name="ag_set_pass_change_code" id="Function7910861" isSystem="false" />
+		<function name="ag_stats" id="Function7910861" isSystem="false" />
+		<function name="ag_update_barcode" id="Function7910861" isSystem="false" />
+		<function name="ag_update_geo_info" id="Function7910861" isSystem="false" />
+		<function name="ag_update_kit" id="Function7910861" isSystem="false" />
+		<function name="ag_update_kit_password" id="Function7910861" isSystem="false" />
+		<function name="ag_update_login" id="Function7910861" isSystem="false" />
+		<function name="ag_verify_kit_status" id="Function7910861" isSystem="false" />
+		<function name="ag_verify_password_change_code" id="Function7910861" isSystem="false" />
+		<function name="american_gut_consent_submit" id="Function7910862" isSystem="false" />
+		<function name="get_barcode_proj_type" id="Function7910862" isSystem="false" />
+		<function name="get_project_names" id="Function7910862" isSystem="false" />
+		<function name="set_barcode_proj_type" id="Function7910862" isSystem="false" />
+		<function name="update_akb" id="Function7910862" isSystem="false" />
+		<function name="update_barcode_status" id="Function7910862" isSystem="false" />
+		<function name="uuid_generate_v4" id="Function7910862" isSystem="false" />
+	</schema>
+	<schema name="barcodes" catalogname="ag_test" schemaname="barcodes" defo="y" >
+		<table name="barcode" >
+			<column name="barcode" type="varchar" length="2147483647" jt="12" mandatory="y" />
+			<column name="create_date_time" type="timestamp" length="29" decimal="6" jt="93" >
+				<defo>(&#039;now&#039;::text)::timestamp without time zone</defo>
+			</column>
+			<column name="status" type="varchar" length="100" jt="12" />
+			<column name="scan_date" type="varchar" length="20" jt="12" />
+			<column name="sample_postmark_date" type="varchar" length="20" jt="12" />
+			<column name="biomass_remaining" type="varchar" length="1" jt="12" />
+			<column name="sequencing_status" type="varchar" length="20" jt="12" />
+			<column name="obsolete" type="varchar" length="1" jt="12" />
+			<index name="barcode_pkey" unique="PRIMARY_KEY" >
+				<column name="barcode" />
+			</index>
+		</table>
+		<table name="barcode_exceptions" >
+			<column name="barcode" type="varchar" length="100" jt="12" mandatory="y" />
+			<index name="pk_barcode_exceptions" unique="PRIMARY_KEY" >
+				<column name="barcode" />
+			</index>
+			<fk name="fk_barcode_exceptions" to_schema="barcodes" to_table="barcode" >
+				<fk_column name="barcode" pk="barcode" />
+			</fk>
+		</table>
+		<table name="plate" >
+			<column name="plate_id" type="bigint" length="19" jt="-5" mandatory="y" />
+			<column name="plate" type="varchar" length="50" jt="12" />
+			<column name="sequence_date" type="varchar" length="20" jt="12" />
+			<index name="plate_pkey" unique="PRIMARY_KEY" >
+				<column name="plate_id" />
+			</index>
+		</table>
+		<table name="plate_barcode" >
+			<column name="plate_id" type="bigint" length="19" jt="-5" mandatory="y" />
+			<column name="barcode" type="varchar" length="2147483647" jt="12" mandatory="y" />
+			<index name="idx_plate_barcode" unique="NORMAL" >
+				<column name="barcode" />
+			</index>
+			<index name="idx_plate_barcode_0" unique="NORMAL" >
+				<column name="plate_id" />
+			</index>
+			<fk name="fk_plate_barcode" to_schema="barcodes" to_table="barcode" >
+				<fk_column name="barcode" pk="barcode" />
+			</fk>
+			<fk name="fk_plate_barcode_0" to_schema="barcodes" to_table="plate" >
+				<fk_column name="plate_id" pk="plate_id" />
+			</fk>
+		</table>
+		<table name="project" >
+			<column name="project_id" type="bigint" length="19" jt="-5" mandatory="y" />
+			<column name="project" type="varchar" length="1000" jt="12" />
+			<index name="project_pkey" unique="PRIMARY_KEY" >
+				<column name="project_id" />
+			</index>
+		</table>
+		<table name="project_barcode" >
+			<column name="project_id" type="bigint" length="19" jt="-5" mandatory="y" />
+			<column name="barcode" type="char" length="9" jt="1" mandatory="y" />
+			<index name="project_barcode_pkey" unique="PRIMARY_KEY" >
+				<column name="project_id" />
+				<column name="barcode" />
+			</index>
+			<fk name="fk_pb_to_barcode" to_schema="barcodes" to_table="barcode" >
+				<fk_column name="barcode" pk="barcode" />
+			</fk>
+			<fk name="fk_pb_to_project" to_schema="barcodes" to_table="project" >
+				<fk_column name="project_id" pk="project_id" />
+			</fk>
 		</table>
 	</schema>
 	<schema name="information_schema" catalogname="ag" schemaname="information_schema" defo="y" >
@@ -1295,7 +1360,7 @@ AS $function$areasel$function$
 			<comment><![CDATA[concatenate aggregate input into an array]]></comment>
 		</function>
 		<function name="array_agg_finalfn" id="Function2850043" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.array_agg_finalfn(internal)
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.array_agg_finalfn(internal, anyelement)
  RETURNS anyarray
  LANGUAGE internal
  IMMUTABLE
@@ -1950,8 +2015,40 @@ AS $function$int4_bool$function$
 ]]></string>
 			<comment><![CDATA[convert int4 to boolean]]></comment>
 		</function>
+		<function name="bool_accum" id="Function7910862" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.bool_accum(internal, boolean)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$bool_accum$function$
+]]></string>
+		</function>
+		<function name="bool_accum_inv" id="Function7910862" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.bool_accum_inv(internal, boolean)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$bool_accum_inv$function$
+]]></string>
+		</function>
+		<function name="bool_alltrue" id="Function7910862" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.bool_alltrue(internal)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$bool_alltrue$function$
+]]></string>
+		</function>
 		<function name="bool_and" id="Function2850054" isSystem="false" >
 			<comment><![CDATA[boolean-and aggregate]]></comment>
+		</function>
+		<function name="bool_anytrue" id="Function7910862" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.bool_anytrue(internal)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$bool_anytrue$function$
+]]></string>
 		</function>
 		<function name="bool_or" id="Function2850054" isSystem="false" >
 			<comment><![CDATA[boolean-or aggregate]]></comment>
@@ -2972,6 +3069,14 @@ AS $function$btrecordcmp$function$
 ]]></string>
 			<comment><![CDATA[less-equal-greater]]></comment>
 		</function>
+		<function name="btrecordimagecmp" id="Function7910862" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.btrecordimagecmp(record, record)
+ RETURNS integer
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$btrecordimagecmp$function$
+]]></string>
+		</function>
 		<function name="btreltimecmp" id="Function2850090" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.btreltimecmp(reltime, reltime)
  RETURNS integer
@@ -3200,6 +3305,14 @@ AS $function$bytearecv$function$
 AS $function$byteasend$function$
 ]]></string>
 			<comment><![CDATA[I/O]]></comment>
+		</function>
+		<function name="cardinality" id="Function7910863" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.cardinality(anyarray)
+ RETURNS integer
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$array_cardinality$function$
+]]></string>
 		</function>
 		<function name="cash_cmp" id="Function2850092" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.cash_cmp(money, money)
@@ -4159,6 +4272,15 @@ AS $function$window_cume_dist$function$
 ]]></string>
 			<comment><![CDATA[fractional row number within partition]]></comment>
 		</function>
+		<function name="cume_dist_001" id="Function7910863" isSystem="false" />
+		<function name="cume_dist_final" id="Function7910863" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.cume_dist_final(internal, VARIADIC "any")
+ RETURNS double precision
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$hypothetical_cume_dist_final$function$
+]]></string>
+		</function>
 		<function name="current_database" id="Function2850100" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.current_database()
  RETURNS name
@@ -4772,6 +4894,15 @@ AS $function$degrees$function$
 AS $function$window_dense_rank$function$
 ]]></string>
 			<comment><![CDATA[integer rank without gaps]]></comment>
+		</function>
+		<function name="dense_rank_001" id="Function7910863" isSystem="false" />
+		<function name="dense_rank_final" id="Function7910863" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.dense_rank_final(internal, VARIADIC "any")
+ RETURNS bigint
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$hypothetical_dense_rank_final$function$
+]]></string>
 		</function>
 		<function name="dexp" id="Function2850107" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.dexp(double precision)
@@ -6363,6 +6494,62 @@ AS $function$gin_cmp_tslexeme$function$
 ]]></string>
 			<comment><![CDATA[GIN tsvector support]]></comment>
 		</function>
+		<function name="gin_compare_jsonb" id="Function7910863" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_compare_jsonb(text, text)
+ RETURNS integer
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_compare_jsonb$function$
+]]></string>
+		</function>
+		<function name="gin_consistent_jsonb" id="Function7910863" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_consistent_jsonb(internal, smallint, anyarray, integer, internal, internal, internal, internal)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_consistent_jsonb$function$
+]]></string>
+		</function>
+		<function name="gin_consistent_jsonb_path" id="Function7910863" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_consistent_jsonb_path(internal, smallint, anyarray, integer, internal, internal, internal, internal)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_consistent_jsonb_path$function$
+]]></string>
+		</function>
+		<function name="gin_extract_jsonb" id="Function7910863" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_extract_jsonb(internal, internal, internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_extract_jsonb$function$
+]]></string>
+		</function>
+		<function name="gin_extract_jsonb_path" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_extract_jsonb_path(internal, internal, internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_extract_jsonb_path$function$
+]]></string>
+		</function>
+		<function name="gin_extract_jsonb_query" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_extract_jsonb_query(anyarray, internal, smallint, internal, internal, internal, internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_extract_jsonb_query$function$
+]]></string>
+		</function>
+		<function name="gin_extract_jsonb_query_path" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_extract_jsonb_query_path(anyarray, internal, smallint, internal, internal, internal, internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_extract_jsonb_query_path$function$
+]]></string>
+		</function>
 		<function name="gin_extract_tsquery" id="Function2850121" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_extract_tsquery(tsquery, internal, smallint, internal, internal)
  RETURNS internal
@@ -6397,6 +6584,22 @@ AS $function$gin_extract_tsvector$function$
 		<function name="gin_extract_tsvector_001" id="Function2850121" isSystem="false" >
 			<comment><![CDATA[GIN tsvector support]]></comment>
 		</function>
+		<function name="gin_triconsistent_jsonb" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_triconsistent_jsonb(internal, smallint, anyarray, integer, internal, internal, internal)
+ RETURNS "char"
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_triconsistent_jsonb$function$
+]]></string>
+		</function>
+		<function name="gin_triconsistent_jsonb_path" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_triconsistent_jsonb_path(internal, smallint, anyarray, integer, internal, internal, internal)
+ RETURNS "char"
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_triconsistent_jsonb_path$function$
+]]></string>
+		</function>
 		<function name="gin_tsquery_consistent" id="Function2850121" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_tsquery_consistent(internal, smallint, tsquery, integer, internal, internal)
  RETURNS boolean
@@ -6413,6 +6616,14 @@ AS $function$gin_tsquery_consistent$function$
 		</function>
 		<function name="gin_tsquery_consistent_001" id="Function2850121" isSystem="false" >
 			<comment><![CDATA[GIN tsvector support]]></comment>
+		</function>
+		<function name="gin_tsquery_triconsistent" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.gin_tsquery_triconsistent(internal, smallint, tsquery, integer, internal, internal, internal)
+ RETURNS "char"
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$gin_tsquery_triconsistent$function$
+]]></string>
 		</function>
 		<function name="ginarrayconsistent" id="Function2850121" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.ginarrayconsistent(internal, smallint, anyarray, integer, internal, internal, internal, internal)
@@ -6439,6 +6650,14 @@ AS $function$ginarrayextract$function$
 		</function>
 		<function name="ginarrayextract_001" id="Function2850122" isSystem="false" >
 			<comment><![CDATA[GIN array support (obsolete)]]></comment>
+		</function>
+		<function name="ginarraytriconsistent" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.ginarraytriconsistent(internal, smallint, anyarray, integer, internal, internal, internal)
+ RETURNS "char"
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$ginarraytriconsistent$function$
+]]></string>
 		</function>
 		<function name="ginbeginscan" id="Function2850122" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.ginbeginscan(internal, internal, internal)
@@ -8009,6 +8228,62 @@ AS $function$inet_client_port$function$
 ]]></string>
 			<comment><![CDATA[client's port number for this connection]]></comment>
 		</function>
+		<function name="inet_gist_compress" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.inet_gist_compress(internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$inet_gist_compress$function$
+]]></string>
+		</function>
+		<function name="inet_gist_consistent" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.inet_gist_consistent(internal, inet, integer, oid, internal)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$inet_gist_consistent$function$
+]]></string>
+		</function>
+		<function name="inet_gist_decompress" id="Function7910864" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.inet_gist_decompress(internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$inet_gist_decompress$function$
+]]></string>
+		</function>
+		<function name="inet_gist_penalty" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.inet_gist_penalty(internal, internal, internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$inet_gist_penalty$function$
+]]></string>
+		</function>
+		<function name="inet_gist_picksplit" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.inet_gist_picksplit(internal, internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$inet_gist_picksplit$function$
+]]></string>
+		</function>
+		<function name="inet_gist_same" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.inet_gist_same(inet, inet, internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$inet_gist_same$function$
+]]></string>
+		</function>
+		<function name="inet_gist_union" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.inet_gist_union(internal, internal)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$inet_gist_union$function$
+]]></string>
+		</function>
 		<function name="inet_in" id="Function2850142" isSystem="false" >
 			<comment><![CDATA[I/O]]></comment>
 		</function>
@@ -8336,13 +8611,21 @@ AS $function$int28pl$function$
 			<comment><![CDATA[convert int8 to int2]]></comment>
 		</function>
 		<function name="int2_accum" id="Function2850145" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int2_accum(numeric[], smallint)
- RETURNS numeric[]
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int2_accum(internal, smallint)
+ RETURNS internal
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$int2_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
+		</function>
+		<function name="int2_accum_inv" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int2_accum_inv(internal, smallint)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$int2_accum_inv$function$
+]]></string>
 		</function>
 		<function name="int2_avg_accum" id="Function2850146" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int2_avg_accum(bigint[], smallint)
@@ -8352,6 +8635,14 @@ AS $function$int2_accum$function$
 AS $function$int2_avg_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
+		</function>
+		<function name="int2_avg_accum_inv" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int2_avg_accum_inv(bigint[], smallint)
+ RETURNS bigint[]
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$int2_avg_accum_inv$function$
+]]></string>
 		</function>
 		<function name="int2_mul_cash" id="Function2850146" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int2_mul_cash(smallint, money)
@@ -8427,6 +8718,14 @@ AS $function$int2gt$function$
 		</function>
 		<function name="int2in" id="Function2850146" isSystem="false" >
 			<comment><![CDATA[I/O]]></comment>
+		</function>
+		<function name="int2int4_sum" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int2int4_sum(bigint[])
+ RETURNS bigint
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$int2int4_sum$function$
+]]></string>
 		</function>
 		<function name="int2larger" id="Function2850146" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int2larger(smallint, smallint)
@@ -8872,13 +9171,21 @@ AS $function$int48pl$function$
 			<comment><![CDATA[convert char to int4]]></comment>
 		</function>
 		<function name="int4_accum" id="Function2850151" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int4_accum(numeric[], integer)
- RETURNS numeric[]
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int4_accum(internal, integer)
+ RETURNS internal
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$int4_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
+		</function>
+		<function name="int4_accum_inv" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int4_accum_inv(internal, integer)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$int4_accum_inv$function$
+]]></string>
 		</function>
 		<function name="int4_avg_accum" id="Function2850151" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int4_avg_accum(bigint[], integer)
@@ -8888,6 +9195,14 @@ AS $function$int4_accum$function$
 AS $function$int4_avg_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
+		</function>
+		<function name="int4_avg_accum_inv" id="Function7910865" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int4_avg_accum_inv(bigint[], integer)
+ RETURNS bigint[]
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$int4_avg_accum_inv$function$
+]]></string>
 		</function>
 		<function name="int4_mul_cash" id="Function2850151" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int4_mul_cash(integer, money)
@@ -9411,13 +9726,21 @@ AS $function$int84pl$function$
 			<comment><![CDATA[convert int2 to int8]]></comment>
 		</function>
 		<function name="int8_accum" id="Function2850157" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8_accum(numeric[], bigint)
- RETURNS numeric[]
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8_accum(internal, bigint)
+ RETURNS internal
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$int8_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
+		</function>
+		<function name="int8_accum_inv" id="Function7910866" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8_accum_inv(internal, bigint)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$int8_accum_inv$function$
+]]></string>
 		</function>
 		<function name="int8_avg" id="Function2850157" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8_avg(bigint[])
@@ -9429,10 +9752,10 @@ AS $function$int8_avg$function$
 			<comment><![CDATA[aggregate final function]]></comment>
 		</function>
 		<function name="int8_avg_accum" id="Function2850157" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8_avg_accum(numeric[], bigint)
- RETURNS numeric[]
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8_avg_accum(internal, bigint)
+ RETURNS internal
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$int8_avg_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
@@ -9463,6 +9786,22 @@ AS $function$int8abs$function$
 AS $function$int8and$function$
 ]]></string>
 			<comment><![CDATA[implementation of & operator]]></comment>
+		</function>
+		<function name="int8dec" id="Function7910866" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8dec(bigint)
+ RETURNS bigint
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$int8dec$function$
+]]></string>
+		</function>
+		<function name="int8dec_any" id="Function7910866" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8dec_any(bigint, "any")
+ RETURNS bigint
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$int8dec_any$function$
+]]></string>
 		</function>
 		<function name="int8div" id="Function2850158" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.int8div(bigint, bigint)
@@ -9814,6 +10153,14 @@ AS $function$time_interval$function$
 AS $function$interval_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
+		</function>
+		<function name="interval_accum_inv" id="Function7910866" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.interval_accum_inv(interval[], interval)
+ RETURNS interval[]
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$interval_accum_inv$function$
+]]></string>
 		</function>
 		<function name="interval_avg" id="Function2850161" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.interval_avg(interval[])
@@ -10289,7 +10636,7 @@ AS $function$json_agg_finalfn$function$
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_agg_transfn(internal, anyelement)
  RETURNS internal
  LANGUAGE internal
- IMMUTABLE
+ STABLE
 AS $function$json_agg_transfn$function$
 ]]></string>
 			<comment><![CDATA[json aggregate transition function]]></comment>
@@ -10301,7 +10648,7 @@ AS $function$json_agg_transfn$function$
  IMMUTABLE STRICT
 AS $function$json_array_element$function$
 ]]></string>
-			<comment><![CDATA[get json array element]]></comment>
+			<comment><![CDATA[implementation of -> operator]]></comment>
 		</function>
 		<function name="json_array_element_text" id="Function2850167" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_array_element_text(from_json json, element_index integer)
@@ -10310,7 +10657,7 @@ AS $function$json_array_element$function$
  IMMUTABLE STRICT
 AS $function$json_array_element_text$function$
 ]]></string>
-			<comment><![CDATA[get json array element as text]]></comment>
+			<comment><![CDATA[implementation of ->> operator]]></comment>
 		</function>
 		<function name="json_array_elements" id="Function2850167" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_array_elements(from_json json, OUT value json)
@@ -10321,6 +10668,14 @@ AS $function$json_array_elements$function$
 ]]></string>
 			<comment><![CDATA[key value pairs of a json object]]></comment>
 		</function>
+		<function name="json_array_elements_text" id="Function7910866" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_array_elements_text(from_json json, OUT value text)
+ RETURNS SETOF text
+ LANGUAGE internal
+ IMMUTABLE STRICT ROWS 100
+AS $function$json_array_elements_text$function$
+]]></string>
+		</function>
 		<function name="json_array_length" id="Function2850167" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_array_length(json)
  RETURNS integer
@@ -10330,6 +10685,34 @@ AS $function$json_array_length$function$
 ]]></string>
 			<comment><![CDATA[length of json array]]></comment>
 		</function>
+		<function name="json_build_array" id="Function7910866" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_build_array()
+ RETURNS json
+ LANGUAGE internal
+ STABLE
+AS $function$json_build_array_noargs$function$
+CREATE OR REPLACE FUNCTION pg_catalog.json_build_array(VARIADIC "any")
+ RETURNS json
+ LANGUAGE internal
+ STABLE
+AS $function$json_build_array$function$
+]]></string>
+		</function>
+		<function name="json_build_array_001" id="Function7910866" isSystem="false" />
+		<function name="json_build_object" id="Function7910866" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_build_object()
+ RETURNS json
+ LANGUAGE internal
+ STABLE
+AS $function$json_build_object_noargs$function$
+CREATE OR REPLACE FUNCTION pg_catalog.json_build_object(VARIADIC "any")
+ RETURNS json
+ LANGUAGE internal
+ STABLE
+AS $function$json_build_object$function$
+]]></string>
+		</function>
+		<function name="json_build_object_001" id="Function7910866" isSystem="false" />
 		<function name="json_each" id="Function2850167" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_each(from_json json, OUT key text, OUT value json)
  RETURNS SETOF record
@@ -10357,26 +10740,8 @@ AS $function$json_extract_path$function$
 ]]></string>
 			<comment><![CDATA[get value from json with path elements]]></comment>
 		</function>
-		<function name="json_extract_path_op" id="Function2850167" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_extract_path_op(from_json json, path_elems text[])
- RETURNS json
- LANGUAGE internal
- IMMUTABLE STRICT
-AS $function$json_extract_path$function$
-]]></string>
-			<comment><![CDATA[get value from json with path elements]]></comment>
-		</function>
 		<function name="json_extract_path_text" id="Function2850167" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_extract_path_text(from_json json, VARIADIC path_elems text[])
- RETURNS text
- LANGUAGE internal
- IMMUTABLE STRICT
-AS $function$json_extract_path_text$function$
-]]></string>
-			<comment><![CDATA[get value from json as text with path elements]]></comment>
-		</function>
-		<function name="json_extract_path_text_op" id="Function2850168" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_extract_path_text_op(from_json json, path_elems text[])
  RETURNS text
  LANGUAGE internal
  IMMUTABLE STRICT
@@ -10387,6 +10752,37 @@ AS $function$json_extract_path_text$function$
 		<function name="json_in" id="Function2850168" isSystem="false" >
 			<comment><![CDATA[I/O]]></comment>
 		</function>
+		<function name="json_object" id="Function7910867" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_object(text[])
+ RETURNS json
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$json_object$function$
+CREATE OR REPLACE FUNCTION pg_catalog.json_object(text[], text[])
+ RETURNS json
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$json_object_two_arg$function$
+]]></string>
+		</function>
+		<function name="json_object_001" id="Function7910867" isSystem="false" />
+		<function name="json_object_agg" id="Function7910867" isSystem="false" />
+		<function name="json_object_agg_finalfn" id="Function7910867" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_object_agg_finalfn(internal)
+ RETURNS json
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$json_object_agg_finalfn$function$
+]]></string>
+		</function>
+		<function name="json_object_agg_transfn" id="Function7910867" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_object_agg_transfn(internal, "any", "any")
+ RETURNS internal
+ LANGUAGE internal
+ STABLE
+AS $function$json_object_agg_transfn$function$
+]]></string>
+		</function>
 		<function name="json_object_field" id="Function2850168" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_object_field(from_json json, field_name text)
  RETURNS json
@@ -10394,7 +10790,7 @@ AS $function$json_extract_path_text$function$
  IMMUTABLE STRICT
 AS $function$json_object_field$function$
 ]]></string>
-			<comment><![CDATA[get json object field]]></comment>
+			<comment><![CDATA[implementation of -> operator]]></comment>
 		</function>
 		<function name="json_object_field_text" id="Function2850168" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_object_field_text(from_json json, field_name text)
@@ -10403,7 +10799,7 @@ AS $function$json_object_field$function$
  IMMUTABLE STRICT
 AS $function$json_object_field_text$function$
 ]]></string>
-			<comment><![CDATA[get json object field as text]]></comment>
+			<comment><![CDATA[implementation of ->> operator]]></comment>
 		</function>
 		<function name="json_object_keys" id="Function2850168" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_object_keys(json)
@@ -10452,6 +10848,288 @@ AS $function$json_recv$function$
 AS $function$json_send$function$
 ]]></string>
 			<comment><![CDATA[I/O]]></comment>
+		</function>
+		<function name="json_to_record" id="Function7910867" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_to_record(json)
+ RETURNS record
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$json_to_record$function$
+]]></string>
+		</function>
+		<function name="json_to_recordset" id="Function7910867" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_to_recordset(json)
+ RETURNS SETOF record
+ LANGUAGE internal
+ STABLE ROWS 100
+AS $function$json_to_recordset$function$
+]]></string>
+		</function>
+		<function name="json_typeof" id="Function7910867" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.json_typeof(json)
+ RETURNS text
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$json_typeof$function$
+]]></string>
+		</function>
+		<function name="jsonb_array_element" id="Function7910867" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_array_element(from_json jsonb, element_index integer)
+ RETURNS jsonb
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_array_element$function$
+]]></string>
+		</function>
+		<function name="jsonb_array_element_text" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_array_element_text(from_json jsonb, element_index integer)
+ RETURNS text
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_array_element_text$function$
+]]></string>
+		</function>
+		<function name="jsonb_array_elements" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_array_elements(from_json jsonb, OUT value jsonb)
+ RETURNS SETOF jsonb
+ LANGUAGE internal
+ IMMUTABLE STRICT ROWS 100
+AS $function$jsonb_array_elements$function$
+]]></string>
+		</function>
+		<function name="jsonb_array_elements_text" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_array_elements_text(from_json jsonb, OUT value text)
+ RETURNS SETOF text
+ LANGUAGE internal
+ IMMUTABLE STRICT ROWS 100
+AS $function$jsonb_array_elements_text$function$
+]]></string>
+		</function>
+		<function name="jsonb_array_length" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_array_length(jsonb)
+ RETURNS integer
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_array_length$function$
+]]></string>
+		</function>
+		<function name="jsonb_cmp" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_cmp(jsonb, jsonb)
+ RETURNS integer
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_cmp$function$
+]]></string>
+		</function>
+		<function name="jsonb_contained" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_contained(jsonb, jsonb)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_contained$function$
+]]></string>
+		</function>
+		<function name="jsonb_contains" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_contains(jsonb, jsonb)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_contains$function$
+]]></string>
+		</function>
+		<function name="jsonb_each" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_each(from_json jsonb, OUT key text, OUT value jsonb)
+ RETURNS SETOF record
+ LANGUAGE internal
+ IMMUTABLE STRICT ROWS 100
+AS $function$jsonb_each$function$
+]]></string>
+		</function>
+		<function name="jsonb_each_text" id="Function7910868" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_each_text(from_json jsonb, OUT key text, OUT value text)
+ RETURNS SETOF record
+ LANGUAGE internal
+ IMMUTABLE STRICT ROWS 100
+AS $function$jsonb_each_text$function$
+]]></string>
+		</function>
+		<function name="jsonb_eq" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_eq(jsonb, jsonb)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_eq$function$
+]]></string>
+		</function>
+		<function name="jsonb_exists" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_exists(jsonb, text)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_exists$function$
+]]></string>
+		</function>
+		<function name="jsonb_exists_all" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_exists_all(jsonb, text[])
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_exists_all$function$
+]]></string>
+		</function>
+		<function name="jsonb_exists_any" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_exists_any(jsonb, text[])
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_exists_any$function$
+]]></string>
+		</function>
+		<function name="jsonb_extract_path" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_extract_path(from_json jsonb, VARIADIC path_elems text[])
+ RETURNS jsonb
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_extract_path$function$
+]]></string>
+		</function>
+		<function name="jsonb_extract_path_text" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_extract_path_text(from_json jsonb, VARIADIC path_elems text[])
+ RETURNS text
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_extract_path_text$function$
+]]></string>
+		</function>
+		<function name="jsonb_ge" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_ge(jsonb, jsonb)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_ge$function$
+]]></string>
+		</function>
+		<function name="jsonb_gt" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_gt(jsonb, jsonb)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_gt$function$
+]]></string>
+		</function>
+		<function name="jsonb_hash" id="Function7910869" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_hash(jsonb)
+ RETURNS integer
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_hash$function$
+]]></string>
+		</function>
+		<function name="jsonb_in" id="Function7910869" isSystem="false" />
+		<function name="jsonb_le" id="Function7910870" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_le(jsonb, jsonb)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_le$function$
+]]></string>
+		</function>
+		<function name="jsonb_lt" id="Function7910870" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_lt(jsonb, jsonb)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_lt$function$
+]]></string>
+		</function>
+		<function name="jsonb_ne" id="Function7910870" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_ne(jsonb, jsonb)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_ne$function$
+]]></string>
+		</function>
+		<function name="jsonb_object_field" id="Function7910870" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_object_field(from_json jsonb, field_name text)
+ RETURNS jsonb
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_object_field$function$
+]]></string>
+		</function>
+		<function name="jsonb_object_field_text" id="Function7910870" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_object_field_text(from_json jsonb, field_name text)
+ RETURNS text
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_object_field_text$function$
+]]></string>
+		</function>
+		<function name="jsonb_object_keys" id="Function7910870" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_object_keys(jsonb)
+ RETURNS SETOF text
+ LANGUAGE internal
+ IMMUTABLE STRICT ROWS 100
+AS $function$jsonb_object_keys$function$
+]]></string>
+		</function>
+		<function name="jsonb_out" id="Function7910870" isSystem="false" />
+		<function name="jsonb_populate_record" id="Function7910870" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_populate_record(anyelement, jsonb)
+ RETURNS anyelement
+ LANGUAGE internal
+ STABLE
+AS $function$jsonb_populate_record$function$
+]]></string>
+		</function>
+		<function name="jsonb_populate_recordset" id="Function7910870" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_populate_recordset(anyelement, jsonb)
+ RETURNS SETOF anyelement
+ LANGUAGE internal
+ STABLE ROWS 100
+AS $function$jsonb_populate_recordset$function$
+]]></string>
+		</function>
+		<function name="jsonb_recv" id="Function7910871" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_recv(internal)
+ RETURNS jsonb
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_recv$function$
+]]></string>
+		</function>
+		<function name="jsonb_send" id="Function7910871" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_send(jsonb)
+ RETURNS bytea
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_send$function$
+]]></string>
+		</function>
+		<function name="jsonb_to_record" id="Function7910871" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_to_record(jsonb)
+ RETURNS record
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$jsonb_to_record$function$
+]]></string>
+		</function>
+		<function name="jsonb_to_recordset" id="Function7910871" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_to_recordset(jsonb)
+ RETURNS SETOF record
+ LANGUAGE internal
+ STABLE ROWS 100
+AS $function$jsonb_to_recordset$function$
+]]></string>
+		</function>
+		<function name="jsonb_typeof" id="Function7910871" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.jsonb_typeof(jsonb)
+ RETURNS text
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$jsonb_typeof$function$
+]]></string>
 		</function>
 		<function name="justify_days" id="Function2850168" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.justify_days(interval)
@@ -10945,6 +11623,28 @@ AS $function$lo_export$function$
 ]]></string>
 			<comment><![CDATA[large object export]]></comment>
 		</function>
+		<function name="lo_from_bytea" id="Function7910871" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.lo_from_bytea(oid, bytea)
+ RETURNS oid
+ LANGUAGE internal
+ STRICT
+AS $function$lo_from_bytea$function$
+]]></string>
+		</function>
+		<function name="lo_get" id="Function7910871" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.lo_get(oid)
+ RETURNS bytea
+ LANGUAGE internal
+ STRICT
+AS $function$lo_get$function$
+CREATE OR REPLACE FUNCTION pg_catalog.lo_get(oid, bigint, integer)
+ RETURNS bytea
+ LANGUAGE internal
+ STRICT
+AS $function$lo_get_fragment$function$
+]]></string>
+		</function>
+		<function name="lo_get_001" id="Function7910871" isSystem="false" />
 		<function name="lo_import" id="Function2850175" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.lo_import(text)
  RETURNS oid
@@ -10988,6 +11688,14 @@ AS $function$lo_lseek64$function$
 AS $function$lo_open$function$
 ]]></string>
 			<comment><![CDATA[large object open]]></comment>
+		</function>
+		<function name="lo_put" id="Function7910871" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.lo_put(oid, bigint, bytea)
+ RETURNS void
+ LANGUAGE internal
+ STRICT
+AS $function$lo_put$function$
+]]></string>
 		</function>
 		<function name="lo_tell" id="Function2850175" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.lo_tell(integer)
@@ -11436,6 +12144,52 @@ AS $function$macaddr_send$function$
 ]]></string>
 			<comment><![CDATA[I/O]]></comment>
 		</function>
+		<function name="make_date" id="Function7910872" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.make_date(year integer, month integer, day integer)
+ RETURNS date
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$make_date$function$
+]]></string>
+		</function>
+		<function name="make_interval" id="Function7910872" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.make_interval(years integer DEFAULT 0, months integer DEFAULT 0, weeks integer DEFAULT 0, days integer DEFAULT 0, hours integer DEFAULT 0, mins integer DEFAULT 0, secs double precision DEFAULT 0.0)
+ RETURNS interval
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$make_interval$function$
+]]></string>
+		</function>
+		<function name="make_time" id="Function7910872" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.make_time(hour integer, min integer, sec double precision)
+ RETURNS time without time zone
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$make_time$function$
+]]></string>
+		</function>
+		<function name="make_timestamp" id="Function7910872" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.make_timestamp(year integer, month integer, mday integer, hour integer, min integer, sec double precision)
+ RETURNS timestamp without time zone
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$make_timestamp$function$
+]]></string>
+		</function>
+		<function name="make_timestamptz" id="Function7910872" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.make_timestamptz(year integer, month integer, mday integer, hour integer, min integer, sec double precision)
+ RETURNS timestamp with time zone
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$make_timestamptz$function$
+CREATE OR REPLACE FUNCTION pg_catalog.make_timestamptz(year integer, month integer, mday integer, hour integer, min integer, sec double precision, timezone text)
+ RETURNS timestamp with time zone
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$make_timestamptz_at_timezone$function$
+]]></string>
+		</function>
+		<function name="make_timestamptz_001" id="Function7910872" isSystem="false" />
 		<function name="makeaclitem" id="Function2850180" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.makeaclitem(oid, oid, text, boolean)
  RETURNS aclitem
@@ -11777,6 +12531,15 @@ AS $function$numeric_mod$function$
 		<function name="mod_003" id="Function2850201" isSystem="false" >
 			<comment><![CDATA[modulus]]></comment>
 		</function>
+		<function name="mode" id="Function7910872" isSystem="false" />
+		<function name="mode_final" id="Function7910872" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.mode_final(internal, anyelement)
+ RETURNS anyelement
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$mode_final$function$
+]]></string>
+		</function>
 		<function name="money" id="Function2850201" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.money(numeric)
  RETURNS money
@@ -12085,6 +12848,14 @@ AS $function$network_ne$function$
 ]]></string>
 			<comment><![CDATA[implementation of <> operator]]></comment>
 		</function>
+		<function name="network_overlap" id="Function7910872" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.network_overlap(inet, inet)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$network_overlap$function$
+]]></string>
+		</function>
 		<function name="network_sub" id="Function2850204" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.network_sub(inet, inet)
  RETURNS boolean
@@ -12120,6 +12891,22 @@ AS $function$network_sup$function$
 AS $function$network_supeq$function$
 ]]></string>
 			<comment><![CDATA[implementation of >>= operator]]></comment>
+		</function>
+		<function name="networkjoinsel" id="Function7910873" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.networkjoinsel(internal, oid, internal, smallint, internal)
+ RETURNS double precision
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$networkjoinsel$function$
+]]></string>
+		</function>
+		<function name="networksel" id="Function7910873" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.networksel(internal, oid, internal, integer)
+ RETURNS double precision
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$networksel$function$
+]]></string>
 		</function>
 		<function name="nextval" id="Function2850205" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.nextval(regclass)
@@ -12284,13 +13071,21 @@ AS $function$numeric_abs$function$
 			<comment><![CDATA[implementation of @ operator]]></comment>
 		</function>
 		<function name="numeric_accum" id="Function2850208" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_accum(numeric[], numeric)
- RETURNS numeric[]
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_accum(internal, numeric)
+ RETURNS internal
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$numeric_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
+		</function>
+		<function name="numeric_accum_inv" id="Function7910873" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_accum_inv(internal, numeric)
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$numeric_accum_inv$function$
+]]></string>
 		</function>
 		<function name="numeric_add" id="Function2850208" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_add(numeric, numeric)
@@ -12302,19 +13097,19 @@ AS $function$numeric_add$function$
 			<comment><![CDATA[implementation of + operator]]></comment>
 		</function>
 		<function name="numeric_avg" id="Function2850208" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_avg(numeric[])
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_avg(internal)
  RETURNS numeric
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$numeric_avg$function$
 ]]></string>
 			<comment><![CDATA[aggregate final function]]></comment>
 		</function>
 		<function name="numeric_avg_accum" id="Function2850208" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_avg_accum(numeric[], numeric)
- RETURNS numeric[]
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_avg_accum(internal, numeric)
+ RETURNS internal
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$numeric_avg_accum$function$
 ]]></string>
 			<comment><![CDATA[aggregate transition function]]></comment>
@@ -12524,19 +13319,19 @@ AS $function$numeric_sqrt$function$
 			<comment><![CDATA[square root]]></comment>
 		</function>
 		<function name="numeric_stddev_pop" id="Function2850210" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_stddev_pop(numeric[])
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_stddev_pop(internal)
  RETURNS numeric
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$numeric_stddev_pop$function$
 ]]></string>
 			<comment><![CDATA[aggregate final function]]></comment>
 		</function>
 		<function name="numeric_stddev_samp" id="Function2850210" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_stddev_samp(numeric[])
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_stddev_samp(internal)
  RETURNS numeric
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$numeric_stddev_samp$function$
 ]]></string>
 			<comment><![CDATA[aggregate final function]]></comment>
@@ -12549,6 +13344,14 @@ AS $function$numeric_stddev_samp$function$
 AS $function$numeric_sub$function$
 ]]></string>
 			<comment><![CDATA[implementation of - operator]]></comment>
+		</function>
+		<function name="numeric_sum" id="Function7910873" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_sum(internal)
+ RETURNS numeric
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$numeric_sum$function$
+]]></string>
 		</function>
 		<function name="numeric_transform" id="Function2850211" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_transform(internal)
@@ -12578,19 +13381,19 @@ AS $function$numeric_uplus$function$
 			<comment><![CDATA[implementation of + operator]]></comment>
 		</function>
 		<function name="numeric_var_pop" id="Function2850211" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_var_pop(numeric[])
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_var_pop(internal)
  RETURNS numeric
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$numeric_var_pop$function$
 ]]></string>
 			<comment><![CDATA[aggregate final function]]></comment>
 		</function>
 		<function name="numeric_var_samp" id="Function2850211" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_var_samp(numeric[])
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.numeric_var_samp(internal)
  RETURNS numeric
  LANGUAGE internal
- IMMUTABLE STRICT
+ IMMUTABLE
 AS $function$numeric_var_samp$function$
 ]]></string>
 			<comment><![CDATA[aggregate final function]]></comment>
@@ -12944,6 +13747,22 @@ AS $function$on_sl$function$
 		<function name="opaque_out" id="Function2850216" isSystem="false" >
 			<comment><![CDATA[I/O]]></comment>
 		</function>
+		<function name="ordered_set_transition" id="Function7910873" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.ordered_set_transition(internal, "any")
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$ordered_set_transition$function$
+]]></string>
+		</function>
+		<function name="ordered_set_transition_multi" id="Function7910873" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.ordered_set_transition_multi(internal, VARIADIC "any")
+ RETURNS internal
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$ordered_set_transition_multi$function$
+]]></string>
+		</function>
 		<function name="overlaps" id="Function2850216" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog."overlaps"(time with time zone, time with time zone, time with time zone, time with time zone)
  RETURNS boolean
@@ -13293,6 +14112,69 @@ AS $function$window_percent_rank$function$
 ]]></string>
 			<comment><![CDATA[fractional rank within partition]]></comment>
 		</function>
+		<function name="percent_rank_001" id="Function7910873" isSystem="false" />
+		<function name="percent_rank_final" id="Function7910873" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.percent_rank_final(internal, VARIADIC "any")
+ RETURNS double precision
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$hypothetical_percent_rank_final$function$
+]]></string>
+		</function>
+		<function name="percentile_cont" id="Function7910873" isSystem="false" />
+		<function name="percentile_cont_001" id="Function7910874" isSystem="false" />
+		<function name="percentile_cont_002" id="Function7910874" isSystem="false" />
+		<function name="percentile_cont_003" id="Function7910874" isSystem="false" />
+		<function name="percentile_cont_float8_final" id="Function7910874" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.percentile_cont_float8_final(internal, double precision)
+ RETURNS double precision
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$percentile_cont_float8_final$function$
+]]></string>
+		</function>
+		<function name="percentile_cont_float8_multi_final" id="Function7910874" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.percentile_cont_float8_multi_final(internal, double precision[])
+ RETURNS double precision[]
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$percentile_cont_float8_multi_final$function$
+]]></string>
+		</function>
+		<function name="percentile_cont_interval_final" id="Function7910874" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.percentile_cont_interval_final(internal, double precision)
+ RETURNS interval
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$percentile_cont_interval_final$function$
+]]></string>
+		</function>
+		<function name="percentile_cont_interval_multi_final" id="Function7910874" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.percentile_cont_interval_multi_final(internal, double precision[])
+ RETURNS interval[]
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$percentile_cont_interval_multi_final$function$
+]]></string>
+		</function>
+		<function name="percentile_disc" id="Function7910874" isSystem="false" />
+		<function name="percentile_disc_001" id="Function7910874" isSystem="false" />
+		<function name="percentile_disc_final" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.percentile_disc_final(internal, double precision, anyelement)
+ RETURNS anyelement
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$percentile_disc_final$function$
+]]></string>
+		</function>
+		<function name="percentile_disc_multi_final" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.percentile_disc_multi_final(internal, double precision[], anyelement)
+ RETURNS anyarray
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$percentile_disc_multi_final$function$
+]]></string>
+		</function>
 		<function name="pg_advisory_lock" id="Function2850223" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_advisory_lock(bigint)
  RETURNS void
@@ -13521,9 +14403,23 @@ AS $function$pg_conversion_is_visible$function$
 ]]></string>
 			<comment><![CDATA[is conversion visible in search path?]]></comment>
 		</function>
+		<function name="pg_create_logical_replication_slot" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_create_logical_replication_slot(slot_name name, plugin name, OUT slot_name text, OUT xlog_position pg_lsn)
+ RETURNS record
+ LANGUAGE internal
+AS $function$pg_create_logical_replication_slot$function$
+]]></string>
+		</function>
+		<function name="pg_create_physical_replication_slot" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_create_physical_replication_slot(slot_name name, OUT slot_name name, OUT xlog_position pg_lsn)
+ RETURNS record
+ LANGUAGE internal
+AS $function$pg_create_physical_replication_slot$function$
+]]></string>
+		</function>
 		<function name="pg_create_restore_point" id="Function2850226" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_create_restore_point(text)
- RETURNS text
+ RETURNS pg_lsn
  LANGUAGE internal
  STRICT
 AS $function$pg_create_restore_point$function$
@@ -13532,7 +14428,7 @@ AS $function$pg_create_restore_point$function$
 		</function>
 		<function name="pg_current_xlog_insert_location" id="Function2850226" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_current_xlog_insert_location()
- RETURNS text
+ RETURNS pg_lsn
  LANGUAGE internal
  STRICT
 AS $function$pg_current_xlog_insert_location$function$
@@ -13541,7 +14437,7 @@ AS $function$pg_current_xlog_insert_location$function$
 		</function>
 		<function name="pg_current_xlog_location" id="Function2850227" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_current_xlog_location()
- RETURNS text
+ RETURNS pg_lsn
  LANGUAGE internal
  STRICT
 AS $function$pg_current_xlog_location$function$
@@ -13582,6 +14478,13 @@ AS $function$pg_database_size_oid$function$
 AS $function$pg_describe_object$function$
 ]]></string>
 			<comment><![CDATA[get identification of SQL object]]></comment>
+		</function>
+		<function name="pg_drop_replication_slot" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_drop_replication_slot(name)
+ RETURNS void
+ LANGUAGE internal
+AS $function$pg_drop_replication_slot$function$
+]]></string>
 		</function>
 		<function name="pg_encoding_max_length" id="Function2850227" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_encoding_max_length(integer)
@@ -13637,6 +14540,14 @@ AS $function$pg_extension_update_paths$function$
 ]]></string>
 			<comment><![CDATA[list an extension's version update paths]]></comment>
 		</function>
+		<function name="pg_filenode_relation" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_filenode_relation(oid, oid)
+ RETURNS regclass
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$pg_filenode_relation$function$
+]]></string>
+		</function>
 		<function name="pg_function_is_visible" id="Function2850228" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_function_is_visible(oid)
  RETURNS boolean
@@ -13679,6 +14590,14 @@ AS $function$pg_get_expr_ext$function$
 		</function>
 		<function name="pg_get_expr_001" id="Function2850228" isSystem="false" >
 			<comment><![CDATA[deparse an encoded expression with pretty-print option]]></comment>
+		</function>
+		<function name="pg_get_function_arg_default" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_get_function_arg_default(oid, integer)
+ RETURNS text
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$pg_get_function_arg_default$function$
+]]></string>
 		</function>
 		<function name="pg_get_function_arguments" id="Function2850228" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_get_function_arguments(oid)
@@ -13750,6 +14669,14 @@ AS $function$pg_get_keywords$function$
 AS $function$pg_get_multixact_members$function$
 ]]></string>
 			<comment><![CDATA[view members of a multixactid]]></comment>
+		</function>
+		<function name="pg_get_replication_slots" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_get_replication_slots(OUT slot_name name, OUT plugin name, OUT slot_type text, OUT datoid oid, OUT active boolean, OUT xmin xid, OUT catalog_xmin xid, OUT restart_lsn pg_lsn)
+ RETURNS SETOF record
+ LANGUAGE internal
+ STABLE ROWS 10
+AS $function$pg_get_replication_slots$function$
+]]></string>
 		</function>
 		<function name="pg_get_ruledef" id="Function2850229" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_get_ruledef(oid)
@@ -13958,7 +14885,7 @@ AS $function$pg_last_xact_replay_timestamp$function$
 		</function>
 		<function name="pg_last_xlog_receive_location" id="Function2850234" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_last_xlog_receive_location()
- RETURNS text
+ RETURNS pg_lsn
  LANGUAGE internal
  STRICT
 AS $function$pg_last_xlog_receive_location$function$
@@ -13967,7 +14894,7 @@ AS $function$pg_last_xlog_receive_location$function$
 		</function>
 		<function name="pg_last_xlog_replay_location" id="Function2850234" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_last_xlog_replay_location()
- RETURNS text
+ RETURNS pg_lsn
  LANGUAGE internal
  STRICT
 AS $function$pg_last_xlog_replay_location$function$
@@ -13992,6 +14919,38 @@ AS $function$pg_lock_status$function$
 ]]></string>
 			<comment><![CDATA[view system lock information]]></comment>
 		</function>
+		<function name="pg_logical_slot_get_binary_changes" id="Function7910875" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_logical_slot_get_binary_changes(slot_name name, upto_lsn pg_lsn, upto_nchanges integer, VARIADIC options text[] DEFAULT '{}'::text[], OUT location pg_lsn, OUT xid xid, OUT data bytea)
+ RETURNS SETOF record
+ LANGUAGE internal
+ COST 1000
+AS $function$pg_logical_slot_get_binary_changes$function$
+]]></string>
+		</function>
+		<function name="pg_logical_slot_get_changes" id="Function7910876" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_logical_slot_get_changes(slot_name name, upto_lsn pg_lsn, upto_nchanges integer, VARIADIC options text[] DEFAULT '{}'::text[], OUT location pg_lsn, OUT xid xid, OUT data text)
+ RETURNS SETOF record
+ LANGUAGE internal
+ COST 1000
+AS $function$pg_logical_slot_get_changes$function$
+]]></string>
+		</function>
+		<function name="pg_logical_slot_peek_binary_changes" id="Function7910876" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_logical_slot_peek_binary_changes(slot_name name, upto_lsn pg_lsn, upto_nchanges integer, VARIADIC options text[] DEFAULT '{}'::text[], OUT location pg_lsn, OUT xid xid, OUT data bytea)
+ RETURNS SETOF record
+ LANGUAGE internal
+ COST 1000
+AS $function$pg_logical_slot_peek_binary_changes$function$
+]]></string>
+		</function>
+		<function name="pg_logical_slot_peek_changes" id="Function7910876" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_logical_slot_peek_changes(slot_name name, upto_lsn pg_lsn, upto_nchanges integer, VARIADIC options text[] DEFAULT '{}'::text[], OUT location pg_lsn, OUT xid xid, OUT data text)
+ RETURNS SETOF record
+ LANGUAGE internal
+ COST 1000
+AS $function$pg_logical_slot_peek_changes$function$
+]]></string>
+		</function>
 		<function name="pg_ls_dir" id="Function2850234" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_ls_dir(text)
  RETURNS SETOF text
@@ -14000,6 +14959,96 @@ AS $function$pg_lock_status$function$
 AS $function$pg_ls_dir$function$
 ]]></string>
 			<comment><![CDATA[list all files in a directory]]></comment>
+		</function>
+		<function name="pg_lsn_cmp" id="Function7910876" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_cmp(pg_lsn, pg_lsn)
+ RETURNS integer
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_cmp$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_eq" id="Function7910876" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_eq(pg_lsn, pg_lsn)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_eq$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_ge" id="Function7910876" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_ge(pg_lsn, pg_lsn)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_ge$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_gt" id="Function7910878" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_gt(pg_lsn, pg_lsn)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_gt$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_hash" id="Function7910878" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_hash(pg_lsn)
+ RETURNS integer
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_hash$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_in" id="Function7910878" isSystem="false" />
+		<function name="pg_lsn_le" id="Function7910878" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_le(pg_lsn, pg_lsn)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_le$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_lt" id="Function7910878" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_lt(pg_lsn, pg_lsn)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_lt$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_mi" id="Function7910879" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_mi(pg_lsn, pg_lsn)
+ RETURNS numeric
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_mi$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_ne" id="Function7910879" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_ne(pg_lsn, pg_lsn)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_ne$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_out" id="Function7910879" isSystem="false" />
+		<function name="pg_lsn_recv" id="Function7910879" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_recv(internal)
+ RETURNS pg_lsn
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_recv$function$
+]]></string>
+		</function>
+		<function name="pg_lsn_send" id="Function7910879" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_lsn_send(pg_lsn)
+ RETURNS bytea
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$pg_lsn_send$function$
+]]></string>
 		</function>
 		<function name="pg_my_temp_schema" id="Function2850235" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_my_temp_schema()
@@ -14245,9 +15294,25 @@ AS $function$pg_sleep$function$
 ]]></string>
 			<comment><![CDATA[sleep for the specified time in seconds]]></comment>
 		</function>
+		<function name="pg_sleep_for" id="Function7910880" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_sleep_for(interval)
+ RETURNS void
+ LANGUAGE sql
+ STRICT COST 1
+AS $function$select pg_catalog.pg_sleep(extract(epoch from pg_catalog.clock_timestamp() operator(pg_catalog.+) $1) operator(pg_catalog.-) extract(epoch from pg_catalog.clock_timestamp()))$function$
+]]></string>
+		</function>
+		<function name="pg_sleep_until" id="Function7910880" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_sleep_until(timestamp with time zone)
+ RETURNS void
+ LANGUAGE sql
+ STRICT COST 1
+AS $function$select pg_catalog.pg_sleep(extract(epoch from $1) operator(pg_catalog.-) extract(epoch from pg_catalog.clock_timestamp()))$function$
+]]></string>
+		</function>
 		<function name="pg_start_backup" id="Function2850238" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_start_backup(label text, fast boolean DEFAULT false)
- RETURNS text
+ RETURNS pg_lsn
  LANGUAGE internal
  STRICT
 AS $function$pg_start_backup$function$
@@ -14272,7 +15337,7 @@ AS $function$pg_stat_file$function$
 			<comment><![CDATA[get information about file]]></comment>
 		</function>
 		<function name="pg_stat_get_activity" id="Function2850238" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stat_get_activity(pid integer, OUT datid oid, OUT pid integer, OUT usesysid oid, OUT application_name text, OUT state text, OUT query text, OUT waiting boolean, OUT xact_start timestamp with time zone, OUT query_start timestamp with time zone, OUT backend_start timestamp with time zone, OUT state_change timestamp with time zone, OUT client_addr inet, OUT client_hostname text, OUT client_port integer)
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stat_get_activity(pid integer, OUT datid oid, OUT pid integer, OUT usesysid oid, OUT application_name text, OUT state text, OUT query text, OUT waiting boolean, OUT xact_start timestamp with time zone, OUT query_start timestamp with time zone, OUT backend_start timestamp with time zone, OUT state_change timestamp with time zone, OUT client_addr inet, OUT client_hostname text, OUT client_port integer, OUT backend_xid xid, OUT backend_xmin xid)
  RETURNS SETOF record
  LANGUAGE internal
  STABLE ROWS 100
@@ -14288,6 +15353,14 @@ AS $function$pg_stat_get_activity$function$
 AS $function$pg_stat_get_analyze_count$function$
 ]]></string>
 			<comment><![CDATA[statistics: number of manual analyzes for a table]]></comment>
+		</function>
+		<function name="pg_stat_get_archiver" id="Function7910880" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stat_get_archiver(OUT archived_count bigint, OUT last_archived_wal text, OUT last_archived_time timestamp with time zone, OUT failed_count bigint, OUT last_failed_wal text, OUT last_failed_time timestamp with time zone, OUT stats_reset timestamp with time zone)
+ RETURNS record
+ LANGUAGE internal
+ STABLE
+AS $function$pg_stat_get_archiver$function$
+]]></string>
 		</function>
 		<function name="pg_stat_get_autoanalyze_count" id="Function2850238" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stat_get_autoanalyze_count(oid)
@@ -14802,6 +15875,14 @@ AS $function$pg_stat_get_live_tuples$function$
 ]]></string>
 			<comment><![CDATA[statistics: number of live tuples]]></comment>
 		</function>
+		<function name="pg_stat_get_mod_since_analyze" id="Function7910880" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stat_get_mod_since_analyze(oid)
+ RETURNS bigint
+ LANGUAGE internal
+ STABLE STRICT
+AS $function$pg_stat_get_mod_since_analyze$function$
+]]></string>
+		</function>
 		<function name="pg_stat_get_numscans" id="Function2850244" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stat_get_numscans(oid)
  RETURNS bigint
@@ -14875,7 +15956,7 @@ AS $function$pg_stat_get_vacuum_count$function$
 			<comment><![CDATA[statistics: number of manual vacuums for a table]]></comment>
 		</function>
 		<function name="pg_stat_get_wal_senders" id="Function2850245" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stat_get_wal_senders(OUT pid integer, OUT state text, OUT sent_location text, OUT write_location text, OUT flush_location text, OUT replay_location text, OUT sync_priority integer, OUT sync_state text)
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stat_get_wal_senders(OUT pid integer, OUT state text, OUT sent_location pg_lsn, OUT write_location pg_lsn, OUT flush_location pg_lsn, OUT replay_location pg_lsn, OUT sync_priority integer, OUT sync_state text)
  RETURNS SETOF record
  LANGUAGE internal
  STABLE ROWS 10
@@ -15026,7 +16107,7 @@ AS $function$pg_stat_reset_single_table_counters$function$
 		</function>
 		<function name="pg_stop_backup" id="Function2850247" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_stop_backup()
- RETURNS text
+ RETURNS pg_lsn
  LANGUAGE internal
  STRICT
 AS $function$pg_stop_backup$function$
@@ -15035,7 +16116,7 @@ AS $function$pg_stop_backup$function$
 		</function>
 		<function name="pg_switch_xlog" id="Function2850247" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_switch_xlog()
- RETURNS text
+ RETURNS pg_lsn
  LANGUAGE internal
  STRICT
 AS $function$pg_switch_xlog$function$
@@ -15263,7 +16344,7 @@ AS $function$pg_typeof$function$
 			<comment><![CDATA[type of the argument]]></comment>
 		</function>
 		<function name="pg_xlog_location_diff" id="Function2850250" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_xlog_location_diff(text, text)
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_xlog_location_diff(pg_lsn, pg_lsn)
  RETURNS numeric
  LANGUAGE internal
  IMMUTABLE STRICT
@@ -15290,7 +16371,7 @@ AS $function$pg_xlog_replay_resume$function$
 			<comment><![CDATA[resume xlog replay, if it was paused]]></comment>
 		</function>
 		<function name="pg_xlogfile_name" id="Function2850250" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_xlogfile_name(text)
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_xlogfile_name(pg_lsn)
  RETURNS text
  LANGUAGE internal
  IMMUTABLE STRICT
@@ -15299,7 +16380,7 @@ AS $function$pg_xlogfile_name$function$
 			<comment><![CDATA[xlog filename, given an xlog location]]></comment>
 		</function>
 		<function name="pg_xlogfile_name_offset" id="Function2850250" isSystem="false" >
-			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_xlogfile_name_offset(wal_location text, OUT file_name text, OUT file_offset integer)
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.pg_xlogfile_name_offset(wal_location pg_lsn, OUT file_name text, OUT file_offset integer)
  RETURNS record
  LANGUAGE internal
  IMMUTABLE STRICT
@@ -16296,6 +17377,15 @@ AS $function$window_rank$function$
 ]]></string>
 			<comment><![CDATA[integer rank with gaps]]></comment>
 		</function>
+		<function name="rank_001" id="Function7910880" isSystem="false" />
+		<function name="rank_final" id="Function7910881" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.rank_final(internal, VARIADIC "any")
+ RETURNS bigint
+ LANGUAGE internal
+ IMMUTABLE
+AS $function$hypothetical_rank_final$function$
+]]></string>
+		</function>
 		<function name="record_eq" id="Function2850265" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.record_eq(record, record)
  RETURNS boolean
@@ -16322,6 +17412,54 @@ AS $function$record_ge$function$
 AS $function$record_gt$function$
 ]]></string>
 			<comment><![CDATA[implementation of > operator]]></comment>
+		</function>
+		<function name="record_image_eq" id="Function7910881" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.record_image_eq(record, record)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$record_image_eq$function$
+]]></string>
+		</function>
+		<function name="record_image_ge" id="Function7910881" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.record_image_ge(record, record)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$record_image_ge$function$
+]]></string>
+		</function>
+		<function name="record_image_gt" id="Function7910881" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.record_image_gt(record, record)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$record_image_gt$function$
+]]></string>
+		</function>
+		<function name="record_image_le" id="Function7910881" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.record_image_le(record, record)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$record_image_le$function$
+]]></string>
+		</function>
+		<function name="record_image_lt" id="Function7910881" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.record_image_lt(record, record)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$record_image_lt$function$
+]]></string>
+		</function>
+		<function name="record_image_ne" id="Function7910881" isSystem="false" >
+			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.record_image_ne(record, record)
+ RETURNS boolean
+ LANGUAGE internal
+ IMMUTABLE STRICT
+AS $function$record_image_ne$function$
+]]></string>
 		</function>
 		<function name="record_in" id="Function2850265" isSystem="false" >
 			<comment><![CDATA[I/O]]></comment>
@@ -19684,6 +20822,12 @@ AS $function$numeric_to_number$function$
 ]]></string>
 			<comment><![CDATA[convert text to numeric]]></comment>
 		</function>
+		<function name="to_regclass" id="Function7910882" isSystem="false" />
+		<function name="to_regoper" id="Function7910882" isSystem="false" />
+		<function name="to_regoperator" id="Function7910882" isSystem="false" />
+		<function name="to_regproc" id="Function7910882" isSystem="false" />
+		<function name="to_regprocedure" id="Function7910882" isSystem="false" />
+		<function name="to_regtype" id="Function7910882" isSystem="false" />
 		<function name="to_timestamp" id="Function2850329" isSystem="false" >
 			<string><![CDATA[CREATE OR REPLACE FUNCTION pg_catalog.to_timestamp(double precision)
  RETURNS timestamp with time zone
@@ -21364,7 +22508,7 @@ AS $function$xpath_exists$function$
 			<comment><![CDATA[test XML value against XPath expression]]></comment>
 		</function>
 	</schema>
-	<connector name="PostgreSQL" database="PostgreSQL" driver_class="org.postgresql.Driver" driver_jar="postgresql-9.2-1003.jdbc3.jar" host="webdev-kl4.colorado.edu" port="5432" instance="ag" user="americangut" schema_mapping="" />
+	<connector name="PostgreSQL" database="PostgreSQL" driver_class="org.postgresql.Driver" driver_jar="postgresql-9.2-1003.jdbc3.jar" host="localhost" port="5432" instance="ag_test" user="jshorens" schema_mapping="" />
 	<layout id="Layout2861625" name="public" joined_routing="y" show_relation_columns="y" >
 		<entity schema="ag" name="ag_survey_answer" color="f7e2c6" x="675" y="690" />
 		<entity schema="ag" name="controlled_vocab_values" color="c6c6f7" x="885" y="45" />
@@ -21384,7 +22528,6 @@ AS $function$xpath_exists$function$
 		<entity schema="ag" name="ag_human_survey" color="c6d9f7" x="1665" y="420" />
 		<entity schema="ag" name="iso_country_lookup" color="ffffff" x="900" y="1620" />
 		<entity schema="ag" name="survey_question_response_type" color="ffcccc" x="690" y="1725" />
-		<entity schema="ag" name="ag_kit_barcodes" color="f7e2c6" x="735" y="885" />
 		<entity schema="ag" name="promoted_survey_ids" color="a8c4ef" x="1425" y="915" />
 		<entity schema="ag" name="survey_question" color="a8c4ef" x="420" y="1530" />
 		<entity schema="ag" name="ag_login" color="f7e2c6" x="705" y="405" />
@@ -21392,19 +22535,21 @@ AS $function$xpath_exists$function$
 		<entity schema="ag" name="ag_consent" color="c6d9f7" x="1440" y="675" />
 		<entity schema="ag" name="ag_survey_multiples_backup" color="cef7c6" x="195" y="90" />
 		<entity schema="ag" name="ag_import_stats_tmp" color="cef7c6" x="420" y="90" />
-		<entity schema="ag" name="barcode" color="c6c6f7" x="375" y="630" />
-		<entity schema="ag" name="project_barcode" color="c6d9f7" x="405" y="945" />
-		<entity schema="ag" name="plate" color="c6d9f7" x="390" y="1035" />
-		<entity schema="ag" name="plate_barcode" color="c6d9f7" x="405" y="1140" />
-		<entity schema="ag" name="project" color="c6d9f7" x="405" y="855" />
-		<entity schema="ag" name="barcode_exceptions" color="c6c6f7" x="45" y="1065" />
 		<entity schema="ag" name="ag_map_markers" color="cef7c6" x="60" y="90" />
-		<entity schema="ag" name="handout_barcode" color="a8c4ef" x="255" y="420" />
 		<entity schema="ag" name="ag_handout_kits" color="ccccff" x="45" y="420" />
 		<entity schema="ag" name="ag_login_surveys" color="ffcccc" x="1425" y="1020" />
 		<entity schema="ag" name="survey_answers" color="a8c4ef" x="1410" y="1230" />
 		<entity schema="ag" name="external_survey_answers" color="a8c4ef" x="1440" y="1350" />
 		<entity schema="ag" name="external_survey" color="a8c4ef" x="1395" y="1470" />
+		<entity schema="barcodes" name="plate" color="a8c4ef" x="300" y="1065" />
+		<entity schema="barcodes" name="project_barcode" color="a8c4ef" x="330" y="975" />
+		<entity schema="barcodes" name="project" color="a8c4ef" x="375" y="885" />
+		<entity schema="barcodes" name="barcode" color="a8c4ef" x="105" y="870" />
+		<entity schema="barcodes" name="plate_barcode" color="a8c4ef" x="135" y="1065" />
+		<entity schema="barcodes" name="barcode_exceptions" color="a8c4ef" x="330" y="810" />
+		<entity schema="ag" name="settings" color="a8c4ef" x="105" y="645" />
+		<entity schema="ag" name="ag_kit_barcodes" color="f7e2c6" x="735" y="885" />
+		<entity schema="ag" name="handout_barcode" color="a8c4ef" x="255" y="420" />
 		<group name="ag_survey_multiples" color="faf6f0" >
 			<comment>Used by : 
    american_gut_consent</comment>
@@ -21449,18 +22594,17 @@ AS $function$xpath_exists$function$
 			<entity schema="ag" name="survey_question_response" />
 			<entity schema="ag" name="iso_country_lookup" />
 		</group>
-		<group name="Group_barcode" color="c4e0f9" >
-			<comment>barcode-related tables</comment>
-			<entity schema="ag" name="barcode_exceptions" />
-			<entity schema="ag" name="barcode" />
-			<entity schema="ag" name="plate_barcode" />
-			<entity schema="ag" name="project_barcode" />
-			<entity schema="ag" name="project" />
-			<entity schema="ag" name="plate" />
-		</group>
 		<group name="Group_handout_kits" color="c4e0f9" >
 			<entity schema="ag" name="ag_handout_kits" />
 			<entity schema="ag" name="handout_barcode" />
+		</group>
+		<group name="Schema_barcodes" color="c4e0f9" >
+			<entity schema="barcodes" name="plate_barcode" />
+			<entity schema="barcodes" name="plate" />
+			<entity schema="barcodes" name="project_barcode" />
+			<entity schema="barcodes" name="project" />
+			<entity schema="barcodes" name="barcode" />
+			<entity schema="barcodes" name="barcode_exceptions" />
 		</group>
 	</layout>
 </project>

--- a/amgut/db/ag.html
+++ b/amgut/db/ag.html
@@ -212,15 +212,15 @@
 <text x='40' y='1345'>survey_questions</text>
 <rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='40' y='1348' width='1105' height='2' />
 
-<!-- ============= Group 'Group_barcode' ============= -->
-<rect class='grp' style='fill:#c4e0f9;' x='29' y='595' width='527' height='635' />
-<text x='40' y='610'>Group_barcode</text>
-<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='40' y='613' width='505' height='2' />
-
 <!-- ============= Group 'Group_handout_kits' ============= -->
 <rect class='grp' style='fill:#c4e0f9;' x='29' y='385' width='392' height='185' />
 <text x='40' y='400'>Group_handout_kits</text>
 <rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='40' y='403' width='370' height='2' />
+
+<!-- ============= Group 'Schema_barcodes' ============= -->
+<rect class='grp' style='fill:#c4e0f9;' x='89' y='775' width='392' height='395' />
+<text x='100' y='790'>Schema_barcodes</text>
+<rect style='fill:url(#groupUnderTitleLine); stroke-width:2;' x='100' y='793' width='370' height='2' />
 
 <path transform='translate(7,0)' marker-start='url(#foot)'     d='M 825 720 L 832,720 Q 840,720 840,712 L 840,630' >
 	<title>Foreign Key fk_sur_an_to_ag_login
@@ -317,22 +317,7 @@
 	survey_question_response_type references survey_response_types ( survey_response_type )</title>
 </path>
 <text x='892' y='1765' transform='rotate(0 892,1765)' title='Foreign Key fk_human_survey_question_response_type
-	survey_question_response_type references survey_response_types ( survey_response_type )' style='fill:#a1a0a0;'>survey_response_type</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 915 930 L 1072,930 Q 1080,930 1080,922 L 1080,727 Q 1080,720 1087,720 L 1095,720' >
-	<title>Foreign Key fk_ag_kit_barcodes
-	ag_kit_barcodes references ag_kit ( ag_kit_id )</title>
-</path>
-<text x='922' y='925' transform='rotate(0 922,925)' title='Foreign Key fk_ag_kit_barcodes
-	ag_kit_barcodes references ag_kit ( ag_kit_id )' style='fill:#a1a0a0;'>ag_kit_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 720 945 L 562,945 Q 555,945 555,937 L 555,667 Q 555,660 547,660 L 540,660' >
-	<title>Foreign Key fk_ag_kit_barcodes_0
-	ag_kit_barcodes references barcode ( barcode )</title>
-</path>
-<text x='678' y='940' transform='rotate(0 678,940)' title='Foreign Key fk_ag_kit_barcodes_0
-	ag_kit_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 915 960 L 1387,960 Q 1395,960 1395,967 L 1395,1057 Q 1395,1065 1402,1065 L 1410,1065' >
-	<title>Foreign Key fk_ag_kit_barcodes_1
-	ag_kit_barcodes references ag_login_surveys ( survey_id )</title>
-</path>
-<text x='922' y='955' transform='rotate(0 922,955)' title='Foreign Key fk_ag_kit_barcodes_1
-	ag_kit_barcodes references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1410 945 L 1402,945 Q 1395,945 1395,952 L 1395,975' >
+	survey_question_response_type references survey_response_types ( survey_response_type )' style='fill:#a1a0a0;'>survey_response_type</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1410 945 L 1402,945 Q 1395,945 1395,952 L 1395,975' >
 	<title>Foreign Key fk_promoted_survey_ids
 	promoted_survey_ids references ag_login_surveys ( survey_id )</title>
 </path>
@@ -342,42 +327,7 @@
 	ag_consent references ag_login ( ag_login_id )</title>
 </path>
 <text x='1365' y='700' transform='rotate(0 1365,700)' title='Foreign Key fk_american_gut_consent
-	ag_consent references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 390 990 L 352,990 Q 345,990 345,982 L 345,975' >
-	<title>Foreign Key fk_pb_to_barcode
-	project_barcode references barcode ( barcode )</title>
-</path>
-<text x='348' y='985' transform='rotate(0 348,985)' title='Foreign Key fk_pb_to_barcode
-	project_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 390 975 L 382,975 Q 375,975 375,967 L 375,892 Q 375,885 382,885 L 390,885' >
-	<title>Foreign Key fk_pb_to_project
-	project_barcode references project ( project_id )</title>
-</path>
-<text x='338' y='970' transform='rotate(0 338,970)' title='Foreign Key fk_pb_to_project
-	project_barcode references project ( project_id )' style='fill:#a1a0a0;'>project_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 390 1185 L 352,1185 Q 345,1185 345,1177 L 345,1080' >
-	<title>Foreign Key fk_plate_barcode
-	plate_barcode references barcode ( barcode )</title>
-</path>
-<text x='348' y='1180' transform='rotate(0 348,1180)' title='Foreign Key fk_plate_barcode
-	plate_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 390 1170 L 367,1170 Q 360,1170 360,1162 L 360,1072 Q 360,1065 367,1065 L 375,1065' >
-	<title>Foreign Key fk_plate_barcode_0
-	plate_barcode references plate ( plate_id )</title>
-</path>
-<text x='350' y='1165' transform='rotate(0 350,1165)' title='Foreign Key fk_plate_barcode_0
-	plate_barcode references plate ( plate_id )' style='fill:#a1a0a0;'>plate_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 165 1095 L 337,1095 Q 345,1095 345,1087 L 345,667 Q 345,660 352,660 L 360,660' >
-	<title>Foreign Key fk_barcode_exceptions
-	barcode_exceptions references barcode ( barcode )</title>
-</path>
-<text x='172' y='1090' transform='rotate(0 172,1090)' title='Foreign Key fk_barcode_exceptions
-	barcode_exceptions references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 405 465 L 547,465 Q 555,465 555,472 L 555,652 Q 555,660 547,660 L 540,660' >
-	<title>Foreign Key fk_handout_barcode
-	handout_barcode references barcode ( barcode )</title>
-</path>
-<text x='412' y='460' transform='rotate(0 412,460)' title='Foreign Key fk_handout_barcode
-	handout_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 240 450 L 180,450' >
-	<title>Foreign Key fk_handout_barcode_0
-	handout_barcode references ag_handout_kits ( kit_id )</title>
-</path>
-<text x='213' y='445' transform='rotate(0 213,445)' title='Foreign Key fk_handout_barcode_0
-	handout_barcode references ag_handout_kits ( kit_id )' style='fill:#a1a0a0;'>kit_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1560 1050 L 1582,1050 Q 1590,1050 1590,1042 L 1590,457 Q 1590,450 1582,450 L 1575,450' >
+	ag_consent references ag_login ( ag_login_id )' style='fill:#a1a0a0;'>ag_login_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 1560 1050 L 1582,1050 Q 1590,1050 1590,1042 L 1590,457 Q 1590,450 1582,450 L 1575,450' >
 	<title>Foreign Key fk_ag_login_surveys
 	ag_login_surveys references ag_login ( ag_login_id )</title>
 </path>
@@ -402,7 +352,57 @@
 	external_survey_answers references external_survey ( external_survey_id )</title>
 </path>
 <text x='1597' y='1390' transform='rotate(0 1597,1390)' title='Foreign Key fk_external_survey
-	external_survey_answers references external_survey ( external_survey_id )' style='fill:#a1a0a0;'>external_survey_id</text><!-- ============= Table 'ag_survey_answer' ============= -->
+	external_survey_answers references external_survey ( external_survey_id )' style='fill:#a1a0a0;'>external_survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 435 1020 L 472,1020 Q 480,1020 480,1012 L 480,930' >
+	<title>Foreign Key fk_pb_to_barcode
+	project_barcode references barcode ( barcode )</title>
+</path>
+<text x='442' y='1015' transform='rotate(0 442,1015)' title='Foreign Key fk_pb_to_barcode
+	project_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 315 1005 L 307,1005 Q 300,1005 300,997 L 300,922 Q 300,915 307,915 L 360,915' >
+	<title>Foreign Key fk_pb_to_project
+	project_barcode references project ( project_id )</title>
+</path>
+<text x='263' y='1000' transform='rotate(0 263,1000)' title='Foreign Key fk_pb_to_project
+	project_barcode references project ( project_id )' style='fill:#a1a0a0;'>project_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 120 1110 L 82,1110 Q 75,1110 75,1102 L 75,907 Q 75,900 82,900 L 90,900' >
+	<title>Foreign Key fk_plate_barcode
+	plate_barcode references barcode ( barcode )</title>
+</path>
+<text x='78' y='1105' transform='rotate(0 78,1105)' title='Foreign Key fk_plate_barcode
+	plate_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 225 1095 L 285,1095' >
+	<title>Foreign Key fk_plate_barcode_0
+	plate_barcode references plate ( plate_id )</title>
+</path>
+<text x='232' y='1090' transform='rotate(0 232,1090)' title='Foreign Key fk_plate_barcode_0
+	plate_barcode references plate ( plate_id )' style='fill:#a1a0a0;'>plate_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 315 840 L 292,840 Q 285,840 285,847 L 285,855' >
+	<title>Foreign Key fk_barcode_exceptions
+	barcode_exceptions references barcode ( barcode )</title>
+</path>
+<text x='273' y='835' transform='rotate(0 273,835)' title='Foreign Key fk_barcode_exceptions
+	barcode_exceptions references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 915 930 L 1072,930 Q 1080,930 1080,922 L 1080,727 Q 1080,720 1087,720 L 1095,720' >
+	<title>Foreign Key fk_ag_kit_barcodes
+	ag_kit_barcodes references ag_kit ( ag_kit_id )</title>
+</path>
+<text x='922' y='925' transform='rotate(0 922,925)' title='Foreign Key fk_ag_kit_barcodes
+	ag_kit_barcodes references ag_kit ( ag_kit_id )' style='fill:#a1a0a0;'>ag_kit_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'  style='stroke-dasharray:4,2;'  d='M 915 960 L 1387,960 Q 1395,960 1395,967 L 1395,1057 Q 1395,1065 1402,1065 L 1410,1065' >
+	<title>Foreign Key fk_ag_kit_barcodes_1
+	ag_kit_barcodes references ag_login_surveys ( survey_id )</title>
+</path>
+<text x='922' y='955' transform='rotate(0 922,955)' title='Foreign Key fk_ag_kit_barcodes_1
+	ag_kit_barcodes references ag_login_surveys ( survey_id )' style='fill:#a1a0a0;'>survey_id</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 720 945 L 487,945 Q 480,945 480,937 L 480,787 Q 480,780 472,780 L 292,780 Q 285,780 285,787 L 285,892 Q 285,900 277,900 L 270,900' >
+	<title>Foreign Key fk_ag_kit_barcodes_barcode
+	ag_kit_barcodes references barcode ( barcode )</title>
+</path>
+<text x='678' y='940' transform='rotate(0 678,940)' title='Foreign Key fk_ag_kit_barcodes_barcode
+	ag_kit_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)' marker-end='url(#arrow)'    d='M 240 450 L 180,450' >
+	<title>Foreign Key fk_handout_barcode_0
+	handout_barcode references ag_handout_kits ( kit_id )</title>
+</path>
+<text x='213' y='445' transform='rotate(0 213,445)' title='Foreign Key fk_handout_barcode_0
+	handout_barcode references ag_handout_kits ( kit_id )' style='fill:#a1a0a0;'>kit_id</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 405 465 L 412,465 Q 420,465 420,472 L 420,772 Q 420,780 412,780 L 405,780' >
+	<title>Foreign Key fk_handout_barcode_barcode
+	handout_barcode references barcode ( barcode )</title>
+</path>
+<text x='412' y='460' transform='rotate(0 412,460)' title='Foreign Key fk_handout_barcode_barcode
+	handout_barcode references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><!-- ============= Table 'ag_survey_answer' ============= -->
 <rect class='table' x='675' y='683' width='150' height='120' rx='7' ry='7' />
 <path d='M 675.50 709.50 L 675.50 690.50 Q 675.50 683.50 682.50 683.50 L 817.50 683.50 Q 824.50 683.50 824.50 690.50 L 824.50 709.50 L675.50 709.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#ag_survey_answer'><text x='700' y='697' class='tableTitle'>ag_survey_answer</text><title>Table ag.ag_survey_answer</title></a>
@@ -413,7 +413,7 @@
 <a xlink:href='#participant_name'><text x='693' y='742'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
   <use id='nn' x='677' y='747' xlink:href='#nn'/><a xlink:href='#question'><use id='pk' x='677' y='746' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name, question ) </title></a>
 <a xlink:href='#question'><text x='693' y='757'>question</text><title>question varchar&#040;100&#041; not null</title></a>
-  <a xlink:href='#ag_survery_answer_id'><text x='693' y='772'>ag_survery_answer_id</text><title>ag_survery_answer_id uuid default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
+  <a xlink:href='#ag_survery_answer_id'><text x='693' y='772'>ag_survery_answer_id</text><title>ag_survery_answer_id uuid default ag&#046;uuid&#095;generate&#095;v4&#040;&#041;</title></a>
   <a xlink:href='#answer'><text x='693' y='787'>answer</text><title>answer varchar&#040;4000&#041;</title></a>
 
 <!-- ============= Table 'controlled_vocab_values' ============= -->
@@ -506,7 +506,7 @@
 <a xlink:href='#survey_response_types'><text x='1001' y='1747' class='tableTitle'>survey_response_types</text><title>Table ag.survey_response_types
 Stores every possible type of response&#046;  The response type will be processed in python to determine how the question is represented in the interface&#046;</title></a>
   <use id='nn' x='992' y='1767' xlink:href='#nn'/><a xlink:href='#survey_response_type'><use id='pk' x='992' y='1766' xlink:href='#pk'/><title>Primary Key  ( survey_response_type ) </title></a>
-<a xlink:href='#survey_response_type'><text x='1008' y='1777'>survey_response_type</text><title>survey_response_type varchar not null</title></a>
+<a xlink:href='#survey_response_type'><text x='1008' y='1777'>survey_response_type</text><title>survey_response_type varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#survey_response_type'><use id='ref' x='1128' y='1766' xlink:href='#ref'/><title>Referred by survey_question_response_type ( survey_response_type ) </title></a>
 
 <!-- ============= Table 'surveys' ============= -->
@@ -529,24 +529,24 @@ The order that this group will be displayed in</title></a>
 <a xlink:href='#group_order'><use id='ref' x='138' y='1391' xlink:href='#ref'/><title>Referred by group_questions ( survey_group -> group_order ) 
 Referred by surveys ( survey_group -> group_order ) </title></a>
   <a xlink:href='#american'><use id='unq' x='47' y='1406' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
-<a xlink:href='#american'><text x='63' y='1417'>american</text><title>american varchar
+<a xlink:href='#american'><text x='63' y='1417'>american</text><title>american varchar&#040;2147483647&#041;
 The american english version of the question group&#039;s name</title></a>
   <a xlink:href='#british'><use id='unq' x='47' y='1421' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
-<a xlink:href='#british'><text x='63' y='1432'>british</text><title>british varchar</title></a>
+<a xlink:href='#british'><text x='63' y='1432'>british</text><title>british varchar&#040;2147483647&#041;</title></a>
 
 <!-- ============= Table 'ag_kit' ============= -->
-<rect class='table' x='1110' y='683' width='165' height='210' rx='7' ry='7' />
+<rect class='table' x='1110' y='683' width='165' height='225' rx='7' ry='7' />
 <path d='M 1110.50 709.50 L 1110.50 690.50 Q 1110.50 683.50 1117.50 683.50 L 1267.50 683.50 Q 1274.50 683.50 1274.50 690.50 L 1274.50 709.50 L1110.50 709.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#ag_kit'><text x='1176' y='697' class='tableTitle'>ag_kit</text><title>Table ag.ag_kit</title></a>
   <use id='nn' x='1112' y='717' xlink:href='#nn'/><a xlink:href='#ag_kit_id'><use id='pk' x='1112' y='716' xlink:href='#pk'/><title>Primary Key  ( ag_kit_id ) </title></a>
-<a xlink:href='#ag_kit_id'><text x='1128' y='727'>ag_kit_id</text><title>ag_kit_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
+<a xlink:href='#ag_kit_id'><text x='1128' y='727'>ag_kit_id</text><title>ag_kit_id uuid not null default ag&#046;uuid&#095;generate&#095;v4&#040;&#041;</title></a>
 <a xlink:href='#ag_kit_id'><use id='ref' x='1263' y='716' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( ag_kit_id ) </title></a>
   <use id='nn' x='1112' y='732' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='idx' x='1112' y='731' xlink:href='#idx'/><title>Index  ( ag_login_id ) </title></a>
 <a xlink:href='#ag_login_id'><text x='1128' y='742'>ag_login_id</text><title>ag_login_id uuid not null</title></a>
 <a xlink:href='#ag_login_id'><use id='fk' x='1263' y='731' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) </title></a>
   <use id='nn' x='1112' y='747' xlink:href='#nn'/><a xlink:href='#supplied_kit_id'><use id='unq' x='1112' y='746' xlink:href='#unq'/><title>Unique Index  ( supplied_kit_id ) </title></a>
 <a xlink:href='#supplied_kit_id'><text x='1128' y='757'>supplied_kit_id</text><title>supplied_kit_id varchar&#040;50&#041; not null</title></a>
-  <a xlink:href='#kit_password'><text x='1128' y='772'>kit_password</text><title>kit_password varchar&#040;50&#041;</title></a>
+  <a xlink:href='#kit_password'><text x='1128' y='772'>kit_password</text><title>kit_password varchar&#040;60&#041;</title></a>
   <use id='nn' x='1112' y='777' xlink:href='#nn'/><a xlink:href='#swabs_per_kit'><text x='1128' y='787'>swabs_per_kit</text><title>swabs_per_kit bigint not null</title></a>
   <a xlink:href='#kit_verification_code'><text x='1128' y='802'>kit_verification_code</text><title>kit_verification_code varchar&#040;50&#041;</title></a>
   <a xlink:href='#kit_verified'><text x='1128' y='817'>kit_verified</text><title>kit_verified char&#040;1&#041; default &#039;n&#039;&#058;&#058;bpchar</title></a>
@@ -554,6 +554,8 @@ The american english version of the question group&#039;s name</title></a>
   <a xlink:href='#pass_reset_code'><text x='1128' y='847'>pass_reset_code</text><title>pass_reset_code varchar&#040;20&#041;</title></a>
   <a xlink:href='#pass_reset_time'><text x='1128' y='862'>pass_reset_time</text><title>pass_reset_time timestamp</title></a>
   <a xlink:href='#print_results'><text x='1128' y='877'>print_results</text><title>print_results varchar&#040;1&#041; default &#039;n&#039;&#058;&#058;character varying</title></a>
+  <a xlink:href='#open_humans_token'><text x='1128' y='892'>open_humans_token</text><title>open_humans_token varchar&#040;64&#041;
+The Open Humans access token corresponding to the Open Humans user that has authorized data sharing with this kit&#046;</title></a>
 
 <!-- ============= Table 'survey_answers_other' ============= -->
 <rect class='table' x='1305' y='1133' width='135' height='90' rx='7' ry='7' />
@@ -561,12 +563,12 @@ The american english version of the question group&#039;s name</title></a>
 <a xlink:href='#survey_answers_other'><text x='1312' y='1147' class='tableTitle'>survey_answers_other</text><title>Table ag.survey_answers_other
 Survey answers for which there are no corresponding foreign keys</title></a>
   <use id='nn' x='1307' y='1167' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1307' y='1166' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) Index  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1323' y='1177'>survey_id</text><title>survey_id varchar not null</title></a>
+<a xlink:href='#survey_id'><text x='1323' y='1177'>survey_id</text><title>survey_id varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#survey_id'><use id='fk' x='1428' y='1166' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
   <use id='nn' x='1307' y='1182' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='1307' y='1181' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) Index  ( survey_question_id ) </title></a>
 <a xlink:href='#survey_question_id'><text x='1323' y='1192'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
 <a xlink:href='#survey_question_id'><use id='fk' x='1428' y='1181' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
-  <use id='nn' x='1307' y='1197' xlink:href='#nn'/><a xlink:href='#response'><text x='1323' y='1207'>response</text><title>response varchar not null</title></a>
+  <use id='nn' x='1307' y='1197' xlink:href='#nn'/><a xlink:href='#response'><text x='1323' y='1207'>response</text><title>response varchar&#040;2147483647&#041; not null</title></a>
 
 <!-- ============= Table 'survey_question_triggers' ============= -->
 <rect class='table' x='645' y='1418' width='150' height='90' rx='7' ry='7' />
@@ -578,7 +580,7 @@ Which question&#047;answer combos trigger other questions</title></a>
 The ID of the question that is triggered</title></a>
 <a xlink:href='#survey_question_id'><use id='fk' x='783' y='1451' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, triggering_response -> response ) </title></a>
   <a xlink:href='#triggering_response'><use id='idx' x='647' y='1466' xlink:href='#idx'/><title>Index  ( triggering_response ) Index  ( triggered_question, triggering_response ) Index  ( survey_question_id, triggering_response ) </title></a>
-<a xlink:href='#triggering_response'><text x='663' y='1477'>triggering_response</text><title>triggering_response varchar
+<a xlink:href='#triggering_response'><text x='663' y='1477'>triggering_response</text><title>triggering_response varchar&#040;2147483647&#041;
 The response to the question that will cause the appearance of the triggered&#095;question</title></a>
 <a xlink:href='#triggering_response'><use id='fk' x='783' y='1466' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, triggering_response -> response ) </title></a>
   <a xlink:href='#triggered_question'><use id='idx' x='647' y='1481' xlink:href='#idx'/><title>Index  ( triggered_question ) Index  ( triggered_question, triggering_response ) </title></a>
@@ -592,11 +594,11 @@ The question that is triggered</title></a>
 <a xlink:href='#survey_response'><text x='696' y='1642' class='tableTitle'>survey_response</text><title>Table ag.survey_response
 Stores every possible predictable response on the human survey</title></a>
   <use id='nn' x='692' y='1662' xlink:href='#nn'/><a xlink:href='#american'><use id='pk' x='692' y='1661' xlink:href='#pk'/><title>Primary Key  ( american ) </title></a>
-<a xlink:href='#american'><text x='708' y='1672'>american</text><title>american varchar not null</title></a>
+<a xlink:href='#american'><text x='708' y='1672'>american</text><title>american varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#american'><use id='ref' x='783' y='1661' xlink:href='#ref'/><title>Referred by iso_country_lookup ( country -> american ) 
 Referred by survey_question_response ( response -> american ) </title></a>
   <a xlink:href='#british'><use id='unq' x='692' y='1676' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
-<a xlink:href='#british'><text x='708' y='1687'>british</text><title>british varchar</title></a>
+<a xlink:href='#british'><text x='708' y='1687'>british</text><title>british varchar&#040;2147483647&#041;</title></a>
 
 <!-- ============= Table 'survey_question_response' ============= -->
 <rect class='table' x='690' y='1523' width='165' height='90' rx='7' ry='7' />
@@ -609,12 +611,12 @@ Maps questions to responses</title></a>
 Referred by survey_answers ( survey_question_id, response ) 
 Referred by survey_question_triggers ( survey_question_id, triggering_response -> response ) </title></a>
   <use id='nn' x='692' y='1572' xlink:href='#nn'/><a xlink:href='#response'><use id='pk' x='692' y='1571' xlink:href='#pk'/><title>Primary Key  ( survey_question_id, response ) </title></a>
-<a xlink:href='#response'><text x='708' y='1582'>response</text><title>response varchar not null</title></a>
+<a xlink:href='#response'><text x='708' y='1582'>response</text><title>response varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#response'><use id='fk' x='843' y='1571' xlink:href='#fk'/><title>References survey_response ( response -> american ) 
 Referred by survey_answers ( survey_question_id, response ) 
 Referred by survey_question_triggers ( survey_question_id, triggering_response -> response ) </title></a>
-  <a xlink:href='#display_index'><use id='unq' x='692' y='1586' xlink:href='#unq'/><title>Unique Index  ( survey_question_id, display_index ) </title></a>
-<a xlink:href='#display_index'><text x='708' y='1597'>display_index</text><title>display_index serial
+  <use id='nn' x='692' y='1587' xlink:href='#nn'/><a xlink:href='#display_index'><use id='unq' x='692' y='1586' xlink:href='#unq'/><title>Unique Index  ( survey_question_id, display_index ) </title></a>
+<a xlink:href='#display_index'><text x='708' y='1597'>display_index</text><title>display_index serial not null
 The display order of this response</title></a>
 
 <!-- ============= Table 'ag_human_survey' ============= -->
@@ -742,10 +744,10 @@ The display order of this response</title></a>
 <a xlink:href='#iso_country_lookup'><text x='906' y='1627' class='tableTitle'>iso_country_lookup</text><title>Table ag.iso_country_lookup
 ISO standard codes for countries</title></a>
   <use id='nn' x='902' y='1647' xlink:href='#nn'/><a xlink:href='#iso_code'><use id='pk' x='902' y='1646' xlink:href='#pk'/><title>Primary Key  ( iso_code ) </title></a>
-<a xlink:href='#iso_code'><text x='918' y='1657'>iso_code</text><title>iso_code varchar not null
+<a xlink:href='#iso_code'><text x='918' y='1657'>iso_code</text><title>iso_code varchar&#040;2147483647&#041; not null
 The ISO code for the country</title></a>
   <use id='nn' x='902' y='1662' xlink:href='#nn'/><a xlink:href='#country'><use id='idx' x='902' y='1661' xlink:href='#idx'/><title>Index  ( country ) </title></a>
-<a xlink:href='#country'><text x='918' y='1672'>country</text><title>country varchar not null</title></a>
+<a xlink:href='#country'><text x='918' y='1672'>country</text><title>country varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#country'><use id='fk' x='1008' y='1661' xlink:href='#fk'/><title>References survey_response ( country -> american ) </title></a>
 
 <!-- ============= Table 'survey_question_response_type' ============= -->
@@ -757,40 +759,8 @@ Stores the type of response for each question</title></a>
 <a xlink:href='#survey_question_id'><text x='708' y='1762'>survey_question_id</text><title>survey_question_id bigint</title></a>
 <a xlink:href='#survey_question_id'><use id='fk' x='873' y='1751' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
   <use id='nn' x='692' y='1767' xlink:href='#nn'/><a xlink:href='#survey_response_type'><use id='idx' x='692' y='1766' xlink:href='#idx'/><title>Index  ( survey_response_type ) </title></a>
-<a xlink:href='#survey_response_type'><text x='708' y='1777'>survey_response_type</text><title>survey_response_type varchar not null</title></a>
+<a xlink:href='#survey_response_type'><text x='708' y='1777'>survey_response_type</text><title>survey_response_type varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#survey_response_type'><use id='fk' x='873' y='1766' xlink:href='#fk'/><title>References survey_response_types ( survey_response_type ) </title></a>
-
-<!-- ============= Table 'ag_kit_barcodes' ============= -->
-<rect class='table' x='735' y='878' width='180' height='345' rx='7' ry='7' />
-<path d='M 735.50 904.50 L 735.50 885.50 Q 735.50 878.50 742.50 878.50 L 907.50 878.50 Q 914.50 878.50 914.50 885.50 L 914.50 904.50 L735.50 904.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
-<a xlink:href='#ag_kit_barcodes'><text x='781' y='892' class='tableTitle'>ag_kit_barcodes</text><title>Table ag.ag_kit_barcodes</title></a>
-  <use id='nn' x='737' y='912' xlink:href='#nn'/><a xlink:href='#ag_kit_barcode_id'><use id='pk' x='737' y='911' xlink:href='#pk'/><title>Primary Key  ( ag_kit_barcode_id ) </title></a>
-<a xlink:href='#ag_kit_barcode_id'><text x='753' y='922'>ag_kit_barcode_id</text><title>ag_kit_barcode_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
-  <a xlink:href='#ag_kit_id'><use id='idx' x='737' y='926' xlink:href='#idx'/><title>Index  ( ag_kit_id ) </title></a>
-<a xlink:href='#ag_kit_id'><text x='753' y='937'>ag_kit_id</text><title>ag_kit_id uuid</title></a>
-<a xlink:href='#ag_kit_id'><use id='fk' x='903' y='926' xlink:href='#fk'/><title>References ag_kit ( ag_kit_id ) </title></a>
-  <use id='nn' x='737' y='942' xlink:href='#nn'/><a xlink:href='#barcode'><use id='unq' x='737' y='941' xlink:href='#unq'/><title>Unique Index  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='753' y='952'>barcode</text><title>barcode varchar not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='903' y='941' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
-  <a xlink:href='#survey_id'><use id='idx' x='737' y='956' xlink:href='#idx'/><title>Index  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='753' y='967'>survey_id</text><title>survey_id varchar</title></a>
-<a xlink:href='#survey_id'><use id='fk' x='903' y='956' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
-  <a xlink:href='#sample_barcode_file'><text x='753' y='982'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;500&#041;</title></a>
-  <a xlink:href='#sample_barcode_file_md5'><text x='753' y='997'>sample_barcode_file_md5</text><title>sample_barcode_file_md5 varchar&#040;50&#041;</title></a>
-  <a xlink:href='#site_sampled'><text x='753' y='1012'>site_sampled</text><title>site_sampled varchar&#040;200&#041;</title></a>
-  <a xlink:href='#sample_date'><text x='753' y='1027'>sample_date</text><title>sample_date varchar&#040;20&#041;</title></a>
-  <a xlink:href='#participant_name'><text x='753' y='1042'>participant_name</text><title>participant_name varchar&#040;200&#041;</title></a>
-  <a xlink:href='#sample_time'><text x='753' y='1057'>sample_time</text><title>sample_time varchar&#040;100&#041;</title></a>
-  <a xlink:href='#notes'><text x='753' y='1072'>notes</text><title>notes varchar&#040;2000&#041;</title></a>
-  <a xlink:href='#environment_sampled'><text x='753' y='1087'>environment_sampled</text><title>environment_sampled varchar&#040;100&#041;</title></a>
-  <a xlink:href='#moldy'><text x='753' y='1102'>moldy</text><title>moldy char&#040;1&#041;</title></a>
-  <a xlink:href='#overloaded'><text x='753' y='1117'>overloaded</text><title>overloaded char&#040;1&#041;</title></a>
-  <a xlink:href='#other'><text x='753' y='1132'>other</text><title>other char&#040;1&#041;</title></a>
-  <a xlink:href='#other_text'><text x='753' y='1147'>other_text</text><title>other_text varchar&#040;2000&#041;</title></a>
-  <a xlink:href='#date_of_last_email'><text x='753' y='1162'>date_of_last_email</text><title>date_of_last_email varchar&#040;20&#041;</title></a>
-  <a xlink:href='#results_ready'><text x='753' y='1177'>results_ready</text><title>results_ready varchar&#040;1&#041;</title></a>
-  <a xlink:href='#withdrawn'><text x='753' y='1192'>withdrawn</text><title>withdrawn varchar&#040;1&#041;</title></a>
-  <a xlink:href='#refunded'><text x='753' y='1207'>refunded</text><title>refunded varchar&#040;1&#041;</title></a>
 
 <!-- ============= Table 'promoted_survey_ids' ============= -->
 <rect class='table' x='1425' y='908' width='135' height='60' rx='7' ry='7' />
@@ -798,7 +768,7 @@ Stores the type of response for each question</title></a>
 <a xlink:href='#promoted_survey_ids'><text x='1434' y='922' class='tableTitle'>promoted_survey_ids</text><title>Table ag.promoted_survey_ids
 Keeps track of the survey&#095;ids that correspond to surveys that were ported from first questionnaire to the second</title></a>
   <use id='nn' x='1427' y='942' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1427' y='941' xlink:href='#pk'/><title>Primary Key  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1443' y='952'>survey_id</text><title>survey_id varchar not null</title></a>
+<a xlink:href='#survey_id'><text x='1443' y='952'>survey_id</text><title>survey_id varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#survey_id'><use id='fk' x='1548' y='941' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
 
 <!-- ============= Table 'survey_question' ============= -->
@@ -815,13 +785,13 @@ Referred by survey_question_response ( survey_question_id )
 Referred by survey_question_response_type ( survey_question_id ) 
 Referred by survey_question_triggers ( triggered_question -> survey_question_id ) </title></a>
   <use id='nn' x='422' y='1572' xlink:href='#nn'/><a xlink:href='#question_shortname'><use id='unq' x='422' y='1571' xlink:href='#unq'/><title>Unique Index  ( question_shortname ) </title></a>
-<a xlink:href='#question_shortname'><text x='438' y='1582'>question_shortname</text><title>question_shortname varchar&#040;100&#041; not null default &#039;TODO&#039;
+<a xlink:href='#question_shortname'><text x='438' y='1582'>question_shortname</text><title>question_shortname varchar&#040;100&#041; not null
 A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown</title></a>
   <a xlink:href='#american'><use id='unq' x='422' y='1586' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
-<a xlink:href='#american'><text x='438' y='1597'>american</text><title>american varchar
+<a xlink:href='#american'><text x='438' y='1597'>american</text><title>american varchar&#040;2147483647&#041;
 The american english version of the question</title></a>
   <a xlink:href='#british'><use id='unq' x='422' y='1601' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
-<a xlink:href='#british'><text x='438' y='1612'>british</text><title>british varchar
+<a xlink:href='#british'><text x='438' y='1612'>british</text><title>british varchar&#040;2147483647&#041;
 The british english version of the question</title></a>
 
 <!-- ============= Table 'ag_login' ============= -->
@@ -829,7 +799,7 @@ The british english version of the question</title></a>
 <path d='M 705.50 424.50 L 705.50 405.50 Q 705.50 398.50 712.50 398.50 L 817.50 398.50 Q 824.50 398.50 824.50 405.50 L 824.50 424.50 L705.50 424.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#ag_login'><text x='742' y='412' class='tableTitle'>ag_login</text><title>Table ag.ag_login</title></a>
   <use id='nn' x='707' y='432' xlink:href='#nn'/><a xlink:href='#ag_login_id'><use id='pk' x='707' y='431' xlink:href='#pk'/><title>Primary Key  ( ag_login_id ) </title></a>
-<a xlink:href='#ag_login_id'><text x='723' y='442'>ag_login_id</text><title>ag_login_id uuid not null default uuid&#095;generate&#095;v4&#040;&#041;</title></a>
+<a xlink:href='#ag_login_id'><text x='723' y='442'>ag_login_id</text><title>ag_login_id uuid not null default ag&#046;uuid&#095;generate&#095;v4&#040;&#041;</title></a>
 <a xlink:href='#ag_login_id'><use id='ref' x='813' y='431' xlink:href='#ref'/><title>Referred by ag_animal_survey ( ag_login_id ) 
 Referred by ag_consent ( ag_login_id ) 
 Referred by ag_human_survey ( ag_login_id ) 
@@ -855,10 +825,10 @@ Referred by ag_survey_multiples ( ag_login_id ) </title></a>
 <path d='M 1095.50 64.50 L 1095.50 45.50 Q 1095.50 38.50 1102.50 38.50 L 1207.50 38.50 Q 1214.50 38.50 1214.50 45.50 L 1214.50 64.50 L1095.50 64.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
 <a xlink:href='#zipcodes'><text x='1131' y='52' class='tableTitle'>zipcodes</text><title>Table ag.zipcodes</title></a>
   <use id='nn' x='1097' y='72' xlink:href='#nn'/><a xlink:href='#zipcode'><use id='pk' x='1097' y='71' xlink:href='#pk'/><title>Primary Key  ( zipcode ) </title></a>
-<a xlink:href='#zipcode'><text x='1113' y='82'>zipcode</text><title>zipcode varchar not null</title></a>
-  <a xlink:href='#state'><text x='1113' y='97'>state</text><title>state varchar</title></a>
-  <a xlink:href='#fips_regions'><text x='1113' y='112'>fips_regions</text><title>fips_regions varchar</title></a>
-  <a xlink:href='#city'><text x='1113' y='127'>city</text><title>city varchar</title></a>
+<a xlink:href='#zipcode'><text x='1113' y='82'>zipcode</text><title>zipcode varchar&#040;2147483647&#041; not null</title></a>
+  <a xlink:href='#state'><text x='1113' y='97'>state</text><title>state varchar&#040;2147483647&#041;</title></a>
+  <a xlink:href='#fips_regions'><text x='1113' y='112'>fips_regions</text><title>fips_regions varchar&#040;2147483647&#041;</title></a>
+  <a xlink:href='#city'><text x='1113' y='127'>city</text><title>city varchar&#040;2147483647&#041;</title></a>
   <a xlink:href='#latitude'><text x='1113' y='142'>latitude</text><title>latitude float8</title></a>
   <a xlink:href='#longitude'><text x='1113' y='157'>longitude</text><title>longitude float8</title></a>
   <a xlink:href='#elevation'><text x='1113' y='172'>elevation</text><title>elevation float8</title></a>
@@ -875,7 +845,7 @@ Referred by ag_login_surveys ( ag_login_id, participant_name ) </title></a>
   <use id='nn' x='1442' y='717' xlink:href='#nn'/><a xlink:href='#participant_name'><use id='pk' x='1442' y='716' xlink:href='#pk'/><title>Primary Key  ( ag_login_id, participant_name ) </title></a>
 <a xlink:href='#participant_name'><text x='1458' y='727'>participant_name</text><title>participant_name varchar&#040;200&#041; not null</title></a>
 <a xlink:href='#participant_name'><use id='ref' x='1563' y='716' xlink:href='#ref'/><title>Referred by ag_login_surveys ( ag_login_id, participant_name ) </title></a>
-  <use id='nn' x='1442' y='732' xlink:href='#nn'/><a xlink:href='#participant_email'><text x='1458' y='742'>participant_email</text><title>participant_email varchar not null</title></a>
+  <use id='nn' x='1442' y='732' xlink:href='#nn'/><a xlink:href='#participant_email'><text x='1458' y='742'>participant_email</text><title>participant_email varchar&#040;2147483647&#041; not null</title></a>
   <a xlink:href='#is_juvenile'><text x='1458' y='757'>is_juvenile</text><title>is_juvenile bool</title></a>
   <a xlink:href='#parent_1_name'><text x='1458' y='772'>parent_1_name</text><title>parent_1_name varchar&#040;200&#041;</title></a>
   <a xlink:href='#parent_2_name'><text x='1458' y='787'>parent_2_name</text><title>parent_2_name varchar&#040;200&#041;</title></a>
@@ -883,8 +853,8 @@ Referred by ag_login_surveys ( ag_login_id, participant_name ) </title></a>
   <a xlink:href='#parent_2_code'><text x='1458' y='817'>parent_2_code</text><title>parent_2_code varchar&#040;200&#041;</title></a>
   <a xlink:href='#deceased_parent'><text x='1458' y='832'>deceased_parent</text><title>deceased_parent varchar&#040;10&#041;</title></a>
   <a xlink:href='#date_signed'><text x='1458' y='847'>date_signed</text><title>date_signed date</title></a>
-  <a xlink:href='#assent_obtainer'><text x='1458' y='862'>assent_obtainer</text><title>assent_obtainer varchar</title></a>
-  <a xlink:href='#age_range'><text x='1458' y='877'>age_range</text><title>age_range varchar</title></a>
+  <a xlink:href='#assent_obtainer'><text x='1458' y='862'>assent_obtainer</text><title>assent_obtainer varchar&#040;2147483647&#041;</title></a>
+  <a xlink:href='#age_range'><text x='1458' y='877'>age_range</text><title>age_range varchar&#040;2147483647&#041;</title></a>
 
 <!-- ============= Table 'ag_survey_multiples_backup' ============= -->
 <rect class='table' x='195' y='83' width='180' height='105' rx='7' ry='7' />
@@ -914,74 +884,6 @@ Referred by ag_login_surveys ( ag_login_id, participant_name ) </title></a>
   <a xlink:href='#kit_diff'><text x='438' y='277'>kit_diff</text><title>kit_diff bigint</title></a>
   <a xlink:href='#barcode_diff'><text x='438' y='292'>barcode_diff</text><title>barcode_diff bigint</title></a>
 
-<!-- ============= Table 'barcode' ============= -->
-<rect class='table' x='375' y='623' width='165' height='165' rx='7' ry='7' />
-<path d='M 375.50 649.50 L 375.50 630.50 Q 375.50 623.50 382.50 623.50 L 532.50 623.50 Q 539.50 623.50 539.50 630.50 L 539.50 649.50 L375.50 649.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#barcode'><text x='435' y='637' class='tableTitle'>barcode</text><title>Table ag.barcode</title></a>
-  <use id='nn' x='377' y='657' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='377' y='656' xlink:href='#pk'/><title>Primary Key  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='393' y='667'>barcode</text><title>barcode varchar not null</title></a>
-<a xlink:href='#barcode'><use id='ref' x='528' y='656' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( barcode ) 
-Referred by barcode_exceptions ( barcode ) 
-Referred by handout_barcode ( barcode ) 
-Referred by plate_barcode ( barcode ) 
-Referred by project_barcode ( barcode ) </title></a>
-  <a xlink:href='#create_date_time'><text x='393' y='682'>create_date_time</text><title>create_date_time timestamp default &#040;&#039;now&#039;&#058;&#058;text&#041;&#058;&#058;timestamp without time zone</title></a>
-  <a xlink:href='#status'><text x='393' y='697'>status</text><title>status varchar&#040;100&#041;</title></a>
-  <a xlink:href='#scan_date'><text x='393' y='712'>scan_date</text><title>scan_date varchar&#040;20&#041;</title></a>
-  <a xlink:href='#sample_postmark_date'><text x='393' y='727'>sample_postmark_date</text><title>sample_postmark_date varchar&#040;20&#041;</title></a>
-  <a xlink:href='#biomass_remaining'><text x='393' y='742'>biomass_remaining</text><title>biomass_remaining varchar&#040;1&#041;</title></a>
-  <a xlink:href='#sequencing_status'><text x='393' y='757'>sequencing_status</text><title>sequencing_status varchar&#040;20&#041;</title></a>
-  <a xlink:href='#obsolete'><text x='393' y='772'>obsolete</text><title>obsolete varchar&#040;1&#041;</title></a>
-
-<!-- ============= Table 'project_barcode' ============= -->
-<rect class='table' x='405' y='938' width='105' height='75' rx='7' ry='7' />
-<path d='M 405.50 964.50 L 405.50 945.50 Q 405.50 938.50 412.50 938.50 L 502.50 938.50 Q 509.50 938.50 509.50 945.50 L 509.50 964.50 L405.50 964.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#project_barcode'><text x='413' y='952' class='tableTitle'>project_barcode</text><title>Table ag.project_barcode</title></a>
-  <use id='nn' x='407' y='972' xlink:href='#nn'/><a xlink:href='#project_id'><use id='pk' x='407' y='971' xlink:href='#pk'/><title>Primary Key  ( project_id, barcode ) </title></a>
-<a xlink:href='#project_id'><text x='423' y='982'>project_id</text><title>project_id bigint not null</title></a>
-<a xlink:href='#project_id'><use id='fk' x='498' y='971' xlink:href='#fk'/><title>References project ( project_id ) </title></a>
-  <use id='nn' x='407' y='987' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='407' y='986' xlink:href='#pk'/><title>Primary Key  ( project_id, barcode ) </title></a>
-<a xlink:href='#barcode'><text x='423' y='997'>barcode</text><title>barcode char&#040;9&#041; not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='498' y='986' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
-
-<!-- ============= Table 'plate' ============= -->
-<rect class='table' x='390' y='1028' width='120' height='90' rx='7' ry='7' />
-<path d='M 390.50 1054.50 L 390.50 1035.50 Q 390.50 1028.50 397.50 1028.50 L 502.50 1028.50 Q 509.50 1028.50 509.50 1035.50 L 509.50 1054.50 L390.50 1054.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#plate'><text x='437' y='1042' class='tableTitle'>plate</text><title>Table ag.plate</title></a>
-  <use id='nn' x='392' y='1062' xlink:href='#nn'/><a xlink:href='#plate_id'><use id='pk' x='392' y='1061' xlink:href='#pk'/><title>Primary Key  ( plate_id ) </title></a>
-<a xlink:href='#plate_id'><text x='408' y='1072'>plate_id</text><title>plate_id bigint not null</title></a>
-<a xlink:href='#plate_id'><use id='ref' x='498' y='1061' xlink:href='#ref'/><title>Referred by plate_barcode ( plate_id ) </title></a>
-  <a xlink:href='#plate'><text x='408' y='1087'>plate</text><title>plate varchar&#040;50&#041;</title></a>
-  <a xlink:href='#sequence_date'><text x='408' y='1102'>sequence_date</text><title>sequence_date varchar&#040;20&#041;</title></a>
-
-<!-- ============= Table 'plate_barcode' ============= -->
-<rect class='table' x='405' y='1133' width='90' height='75' rx='7' ry='7' />
-<path d='M 405.50 1159.50 L 405.50 1140.50 Q 405.50 1133.50 412.50 1133.50 L 487.50 1133.50 Q 494.50 1133.50 494.50 1140.50 L 494.50 1159.50 L405.50 1159.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#plate_barcode'><text x='412' y='1147' class='tableTitle'>plate_barcode</text><title>Table ag.plate_barcode</title></a>
-  <use id='nn' x='407' y='1167' xlink:href='#nn'/><a xlink:href='#plate_id'><use id='idx' x='407' y='1166' xlink:href='#idx'/><title>Index  ( plate_id ) </title></a>
-<a xlink:href='#plate_id'><text x='423' y='1177'>plate_id</text><title>plate_id bigint not null</title></a>
-<a xlink:href='#plate_id'><use id='fk' x='483' y='1166' xlink:href='#fk'/><title>References plate ( plate_id ) </title></a>
-  <use id='nn' x='407' y='1182' xlink:href='#nn'/><a xlink:href='#barcode'><use id='idx' x='407' y='1181' xlink:href='#idx'/><title>Index  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='423' y='1192'>barcode</text><title>barcode varchar not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='483' y='1181' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
-
-<!-- ============= Table 'project' ============= -->
-<rect class='table' x='405' y='848' width='90' height='75' rx='7' ry='7' />
-<path d='M 405.50 874.50 L 405.50 855.50 Q 405.50 848.50 412.50 848.50 L 487.50 848.50 Q 494.50 848.50 494.50 855.50 L 494.50 874.50 L405.50 874.50 ' style='fill:url(#tableHeaderGradient5); stroke:none;' />
-<a xlink:href='#project'><text x='431' y='862' class='tableTitle'>project</text><title>Table ag.project</title></a>
-  <use id='nn' x='407' y='882' xlink:href='#nn'/><a xlink:href='#project_id'><use id='pk' x='407' y='881' xlink:href='#pk'/><title>Primary Key  ( project_id ) </title></a>
-<a xlink:href='#project_id'><text x='423' y='892'>project_id</text><title>project_id bigint not null</title></a>
-<a xlink:href='#project_id'><use id='ref' x='483' y='881' xlink:href='#ref'/><title>Referred by project_barcode ( project_id ) </title></a>
-  <a xlink:href='#project'><text x='423' y='907'>project</text><title>project varchar&#040;1000&#041;</title></a>
-
-<!-- ============= Table 'barcode_exceptions' ============= -->
-<rect class='table' x='45' y='1058' width='120' height='60' rx='7' ry='7' />
-<path d='M 45.50 1084.50 L 45.50 1065.50 Q 45.50 1058.50 52.50 1058.50 L 157.50 1058.50 Q 164.50 1058.50 164.50 1065.50 L 164.50 1084.50 L45.50 1084.50 ' style='fill:url(#tableHeaderGradient1); stroke:none;' />
-<a xlink:href='#barcode_exceptions'><text x='50' y='1072' class='tableTitle'>barcode_exceptions</text><title>Table ag.barcode_exceptions</title></a>
-  <use id='nn' x='47' y='1092' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='47' y='1091' xlink:href='#pk'/><title>Primary Key  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='63' y='1102'>barcode</text><title>barcode varchar&#040;100&#041; not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='153' y='1091' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
-
 <!-- ============= Table 'ag_map_markers' ============= -->
 <rect class='table' x='60' y='83' width='105' height='120' rx='7' ry='7' />
 <path d='M 60.50 109.50 L 60.50 90.50 Q 60.50 83.50 67.50 83.50 L 157.50 83.50 Q 164.50 83.50 164.50 90.50 L 164.50 109.50 L60.50 109.50 ' style='fill:url(#tableHeaderGradient6); stroke:none;' />
@@ -992,18 +894,6 @@ Referred by project_barcode ( barcode ) </title></a>
   <a xlink:href='#marker_color'><text x='78' y='172'>marker_color</text><title>marker_color varchar&#040;10&#041;</title></a>
   <a xlink:href='#order_by'><text x='78' y='187'>order_by</text><title>order_by bigint</title></a>
 
-<!-- ============= Table 'handout_barcode' ============= -->
-<rect class='table' x='255' y='413' width='150' height='90' rx='7' ry='7' />
-<path d='M 255.50 439.50 L 255.50 420.50 Q 255.50 413.50 262.50 413.50 L 397.50 413.50 Q 404.50 413.50 404.50 420.50 L 404.50 439.50 L255.50 439.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
-<a xlink:href='#handout_barcode'><text x='282' y='427' class='tableTitle'>handout_barcode</text><title>Table ag.handout_barcode</title></a>
-  <use id='nn' x='257' y='447' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='257' y='446' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) Index  ( kit_id ) </title></a>
-<a xlink:href='#kit_id'><text x='273' y='457'>kit_id</text><title>kit_id varchar not null</title></a>
-<a xlink:href='#kit_id'><use id='fk' x='393' y='446' xlink:href='#fk'/><title>References ag_handout_kits ( kit_id ) </title></a>
-  <use id='nn' x='257' y='462' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='257' y='461' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) Index  ( barcode ) </title></a>
-<a xlink:href='#barcode'><text x='273' y='472'>barcode</text><title>barcode varchar&#040;9&#041; not null</title></a>
-<a xlink:href='#barcode'><use id='fk' x='393' y='461' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
-  <use id='nn' x='257' y='477' xlink:href='#nn'/><a xlink:href='#sample_barcode_file'><text x='273' y='487'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;13&#041; not null</title></a>
-
 <!-- ============= Table 'ag_handout_kits' ============= -->
 <rect class='table' x='45' y='413' width='135' height='135' rx='7' ry='7' />
 <path d='M 45.50 439.50 L 45.50 420.50 Q 45.50 413.50 52.50 413.50 L 172.50 413.50 Q 179.50 413.50 179.50 420.50 L 179.50 439.50 L45.50 439.50 ' style='fill:url(#tableHeaderGradient7); stroke:none;' />
@@ -1011,7 +901,7 @@ Referred by project_barcode ( barcode ) </title></a>
   <use id='nn' x='47' y='447' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='47' y='446' xlink:href='#pk'/><title>Primary Key  ( kit_id ) </title></a>
 <a xlink:href='#kit_id'><text x='63' y='457'>kit_id</text><title>kit_id varchar&#040;9&#041; not null</title></a>
 <a xlink:href='#kit_id'><use id='ref' x='168' y='446' xlink:href='#ref'/><title>Referred by handout_barcode ( kit_id ) </title></a>
-  <a xlink:href='#password'><text x='63' y='472'>password</text><title>password varchar&#040;11&#041;</title></a>
+  <a xlink:href='#password'><text x='63' y='472'>password</text><title>password varchar&#040;60&#041;</title></a>
   <a xlink:href='#verification_code'><text x='63' y='487'>verification_code</text><title>verification_code varchar&#040;5&#041;</title></a>
   <a xlink:href='#swabs_per_kit'><text x='63' y='502'>swabs_per_kit</text><title>swabs_per_kit bigint</title></a>
   <a xlink:href='#print_results'><text x='63' y='517'>print_results</text><title>print_results varchar&#040;1&#041; default &#039;n&#039;&#058;&#058;character varying</title></a>
@@ -1026,15 +916,14 @@ Referred by project_barcode ( barcode ) </title></a>
 <a xlink:href='#ag_login_id'><use id='fk' x='1548' y='1046' xlink:href='#fk'/><title>References ag_login ( ag_login_id ) 
 References ag_consent ( ag_login_id, participant_name ) </title></a>
   <use id='nn' x='1427' y='1062' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1427' y='1061' xlink:href='#pk'/><title>Primary Key  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1443' y='1072'>survey_id</text><title>survey_id varchar not null</title></a>
+<a xlink:href='#survey_id'><text x='1443' y='1072'>survey_id</text><title>survey_id varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#survey_id'><use id='ref' x='1548' y='1061' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( survey_id ) 
+Referred by external_survey_answers ( survey_id ) 
 Referred by promoted_survey_ids ( survey_id ) 
 Referred by survey_answers ( survey_id ) 
-Referred by survey_answers_other ( survey_id ) 
-Referred by external_survey_answers ( survey_id ) 
-Referred by external_survey_answers ( survey_id ) </title></a>
+Referred by survey_answers_other ( survey_id ) </title></a>
   <a xlink:href='#participant_name'><use id='idx' x='1427' y='1076' xlink:href='#idx'/><title>Index  ( participant_name ) Index  ( ag_login_id, participant_name ) </title></a>
-<a xlink:href='#participant_name'><text x='1443' y='1087'>participant_name</text><title>participant_name varchar</title></a>
+<a xlink:href='#participant_name'><text x='1443' y='1087'>participant_name</text><title>participant_name varchar&#040;2147483647&#041;</title></a>
 <a xlink:href='#participant_name'><use id='fk' x='1548' y='1076' xlink:href='#fk'/><title>References ag_consent ( ag_login_id, participant_name ) </title></a>
   <a xlink:href='#vioscreen_status'><text x='1443' y='1102'>vioscreen_status</text><title>vioscreen_status integer</title></a>
 
@@ -1044,7 +933,7 @@ Referred by external_survey_answers ( survey_id ) </title></a>
 <a xlink:href='#survey_answers'><text x='1434' y='1237' class='tableTitle'>survey_answers</text><title>Table ag.survey_answers
 Stores answers to questions of type SINGLE and MULTIPLE</title></a>
   <use id='nn' x='1412' y='1257' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1412' y='1256' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1428' y='1267'>survey_id</text><title>survey_id varchar not null
+<a xlink:href='#survey_id'><text x='1428' y='1267'>survey_id</text><title>survey_id varchar&#040;2147483647&#041; not null
 The unique identifier for the survey</title></a>
 <a xlink:href='#survey_id'><use id='fk' x='1533' y='1256' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
   <use id='nn' x='1412' y='1272' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='1412' y='1271' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_question_id, response ) </title></a>
@@ -1052,7 +941,7 @@ The unique identifier for the survey</title></a>
 The question being answered</title></a>
 <a xlink:href='#survey_question_id'><use id='fk' x='1533' y='1271' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, response ) </title></a>
   <use id='nn' x='1412' y='1287' xlink:href='#nn'/><a xlink:href='#response'><use id='pk' x='1412' y='1286' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id, response ) Index  ( survey_question_id, response ) </title></a>
-<a xlink:href='#response'><text x='1428' y='1297'>response</text><title>response varchar not null
+<a xlink:href='#response'><text x='1428' y='1297'>response</text><title>response varchar&#040;2147483647&#041; not null
 The answer the question being asked</title></a>
 <a xlink:href='#response'><use id='fk' x='1533' y='1286' xlink:href='#fk'/><title>References survey_question_response ( survey_question_id, response ) </title></a>
 
@@ -1062,13 +951,13 @@ The answer the question being asked</title></a>
 <a xlink:href='#external_survey_answers'><text x='1447' y='1357' class='tableTitle'>external_survey_answers</text><title>Table ag.external_survey_answers
 This stores answers to third party surveys in JSON format&#044; keyed to the original survey ID</title></a>
   <use id='nn' x='1442' y='1377' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1442' y='1376' xlink:href='#pk'/><title>Primary Key  ( survey_id ) </title></a>
-<a xlink:href='#survey_id'><text x='1458' y='1387'>survey_id</text><title>survey_id varchar not null</title></a>
+<a xlink:href='#survey_id'><text x='1458' y='1387'>survey_id</text><title>survey_id varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#survey_id'><use id='fk' x='1578' y='1376' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
   <use id='nn' x='1442' y='1392' xlink:href='#nn'/><a xlink:href='#external_survey_id'><use id='idx' x='1442' y='1391' xlink:href='#idx'/><title>Index  ( external_survey_id ) </title></a>
 <a xlink:href='#external_survey_id'><text x='1458' y='1402'>external_survey_id</text><title>external_survey_id bigint not null</title></a>
 <a xlink:href='#external_survey_id'><use id='fk' x='1578' y='1391' xlink:href='#fk'/><title>References external_survey ( external_survey_id ) </title></a>
   <use id='nn' x='1442' y='1407' xlink:href='#nn'/><a xlink:href='#pulldown_date'><text x='1458' y='1417'>pulldown_date</text><title>pulldown_date date not null</title></a>
-  <use id='nn' x='1442' y='1422' xlink:href='#nn'/><a xlink:href='#answers'><text x='1458' y='1432'>answers</text><title>answers varchar not null</title></a>
+  <use id='nn' x='1442' y='1422' xlink:href='#nn'/><a xlink:href='#answers'><text x='1458' y='1432'>answers</text><title>answers json not null</title></a>
 
 <!-- ============= Table 'external_survey' ============= -->
 <rect class='table' x='1395' y='1463' width='195' height='90' rx='7' ry='7' />
@@ -1076,10 +965,130 @@ This stores answers to third party surveys in JSON format&#044; keyed to the ori
 <a xlink:href='#external_survey'><text x='1449' y='1477' class='tableTitle'>external_survey</text><title>Table ag.external_survey</title></a>
   <use id='nn' x='1397' y='1497' xlink:href='#nn'/><a xlink:href='#external_survey_id'><use id='pk' x='1397' y='1496' xlink:href='#pk'/><title>Primary Key  ( external_survey_id ) </title></a>
 <a xlink:href='#external_survey_id'><text x='1413' y='1507'>external_survey_id</text><title>external_survey_id bigserial not null</title></a>
-<a xlink:href='#external_survey_id'><use id='ref' x='1578' y='1496' xlink:href='#ref'/><title>Referred by external_survey_answers ( external_survey_id ) 
-Referred by external_survey_answers ( external_survey_id ) </title></a>
-  <use id='nn' x='1397' y='1512' xlink:href='#nn'/><a xlink:href='#external_survey'><text x='1413' y='1522'>external_survey</text><title>external_survey varchar not null</title></a>
-  <a xlink:href='#external_survey_description'><text x='1413' y='1537'>external_survey_description</text><title>external_survey_description varchar</title></a>
+<a xlink:href='#external_survey_id'><use id='ref' x='1578' y='1496' xlink:href='#ref'/><title>Referred by external_survey_answers ( external_survey_id ) </title></a>
+  <use id='nn' x='1397' y='1512' xlink:href='#nn'/><a xlink:href='#external_survey'><text x='1413' y='1522'>external_survey</text><title>external_survey varchar&#040;2147483647&#041; not null</title></a>
+  <a xlink:href='#external_survey_description'><text x='1413' y='1537'>external_survey_description</text><title>external_survey_description varchar&#040;2147483647&#041;</title></a>
+
+<!-- ============= Table 'plate' ============= -->
+<rect class='table' x='300' y='1058' width='120' height='90' rx='7' ry='7' />
+<path d='M 300.50 1084.50 L 300.50 1065.50 Q 300.50 1058.50 307.50 1058.50 L 412.50 1058.50 Q 419.50 1058.50 419.50 1065.50 L 419.50 1084.50 L300.50 1084.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#plate'><text x='347' y='1072' class='tableTitle'>plate</text><title>Table barcodes.plate</title></a>
+  <use id='nn' x='302' y='1092' xlink:href='#nn'/><a xlink:href='#plate_id'><use id='pk' x='302' y='1091' xlink:href='#pk'/><title>Primary Key  ( plate_id ) </title></a>
+<a xlink:href='#plate_id'><text x='318' y='1102'>plate_id</text><title>plate_id bigint not null</title></a>
+<a xlink:href='#plate_id'><use id='ref' x='408' y='1091' xlink:href='#ref'/><title>Referred by plate_barcode ( plate_id ) </title></a>
+  <a xlink:href='#plate'><text x='318' y='1117'>plate</text><title>plate varchar&#040;50&#041;</title></a>
+  <a xlink:href='#sequence_date'><text x='318' y='1132'>sequence_date</text><title>sequence_date varchar&#040;20&#041;</title></a>
+
+<!-- ============= Table 'project_barcode' ============= -->
+<rect class='table' x='330' y='968' width='105' height='75' rx='7' ry='7' />
+<path d='M 330.50 994.50 L 330.50 975.50 Q 330.50 968.50 337.50 968.50 L 427.50 968.50 Q 434.50 968.50 434.50 975.50 L 434.50 994.50 L330.50 994.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#project_barcode'><text x='338' y='982' class='tableTitle'>project_barcode</text><title>Table barcodes.project_barcode</title></a>
+  <use id='nn' x='332' y='1002' xlink:href='#nn'/><a xlink:href='#project_id'><use id='pk' x='332' y='1001' xlink:href='#pk'/><title>Primary Key  ( project_id, barcode ) </title></a>
+<a xlink:href='#project_id'><text x='348' y='1012'>project_id</text><title>project_id bigint not null</title></a>
+<a xlink:href='#project_id'><use id='fk' x='423' y='1001' xlink:href='#fk'/><title>References project ( project_id ) </title></a>
+  <use id='nn' x='332' y='1017' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='332' y='1016' xlink:href='#pk'/><title>Primary Key  ( project_id, barcode ) </title></a>
+<a xlink:href='#barcode'><text x='348' y='1027'>barcode</text><title>barcode char&#040;9&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='423' y='1016' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+
+<!-- ============= Table 'project' ============= -->
+<rect class='table' x='375' y='878' width='90' height='75' rx='7' ry='7' />
+<path d='M 375.50 904.50 L 375.50 885.50 Q 375.50 878.50 382.50 878.50 L 457.50 878.50 Q 464.50 878.50 464.50 885.50 L 464.50 904.50 L375.50 904.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#project'><text x='401' y='892' class='tableTitle'>project</text><title>Table barcodes.project</title></a>
+  <use id='nn' x='377' y='912' xlink:href='#nn'/><a xlink:href='#project_id'><use id='pk' x='377' y='911' xlink:href='#pk'/><title>Primary Key  ( project_id ) </title></a>
+<a xlink:href='#project_id'><text x='393' y='922'>project_id</text><title>project_id bigint not null</title></a>
+<a xlink:href='#project_id'><use id='ref' x='453' y='911' xlink:href='#ref'/><title>Referred by project_barcode ( project_id ) </title></a>
+  <a xlink:href='#project'><text x='393' y='937'>project</text><title>project varchar&#040;1000&#041;</title></a>
+
+<!-- ============= Table 'barcode' ============= -->
+<rect class='table' x='105' y='863' width='165' height='165' rx='7' ry='7' />
+<path d='M 105.50 889.50 L 105.50 870.50 Q 105.50 863.50 112.50 863.50 L 262.50 863.50 Q 269.50 863.50 269.50 870.50 L 269.50 889.50 L105.50 889.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#barcode'><text x='165' y='877' class='tableTitle'>barcode</text><title>Table barcodes.barcode</title></a>
+  <use id='nn' x='107' y='897' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='107' y='896' xlink:href='#pk'/><title>Primary Key  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='123' y='907'>barcode</text><title>barcode varchar&#040;2147483647&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='ref' x='258' y='896' xlink:href='#ref'/><title>Referred by ag_kit_barcodes ( barcode ) 
+Referred by handout_barcode ( barcode ) 
+Referred by barcode_exceptions ( barcode ) 
+Referred by plate_barcode ( barcode ) 
+Referred by project_barcode ( barcode ) </title></a>
+  <a xlink:href='#create_date_time'><text x='123' y='922'>create_date_time</text><title>create_date_time timestamp default &#040;&#039;now&#039;&#058;&#058;text&#041;&#058;&#058;timestamp without time zone</title></a>
+  <a xlink:href='#status'><text x='123' y='937'>status</text><title>status varchar&#040;100&#041;</title></a>
+  <a xlink:href='#scan_date'><text x='123' y='952'>scan_date</text><title>scan_date varchar&#040;20&#041;</title></a>
+  <a xlink:href='#sample_postmark_date'><text x='123' y='967'>sample_postmark_date</text><title>sample_postmark_date varchar&#040;20&#041;</title></a>
+  <a xlink:href='#biomass_remaining'><text x='123' y='982'>biomass_remaining</text><title>biomass_remaining varchar&#040;1&#041;</title></a>
+  <a xlink:href='#sequencing_status'><text x='123' y='997'>sequencing_status</text><title>sequencing_status varchar&#040;20&#041;</title></a>
+  <a xlink:href='#obsolete'><text x='123' y='1012'>obsolete</text><title>obsolete varchar&#040;1&#041;</title></a>
+
+<!-- ============= Table 'plate_barcode' ============= -->
+<rect class='table' x='135' y='1058' width='90' height='75' rx='7' ry='7' />
+<path d='M 135.50 1084.50 L 135.50 1065.50 Q 135.50 1058.50 142.50 1058.50 L 217.50 1058.50 Q 224.50 1058.50 224.50 1065.50 L 224.50 1084.50 L135.50 1084.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#plate_barcode'><text x='142' y='1072' class='tableTitle'>plate_barcode</text><title>Table barcodes.plate_barcode</title></a>
+  <use id='nn' x='137' y='1092' xlink:href='#nn'/><a xlink:href='#plate_id'><use id='idx' x='137' y='1091' xlink:href='#idx'/><title>Index  ( plate_id ) </title></a>
+<a xlink:href='#plate_id'><text x='153' y='1102'>plate_id</text><title>plate_id bigint not null</title></a>
+<a xlink:href='#plate_id'><use id='fk' x='213' y='1091' xlink:href='#fk'/><title>References plate ( plate_id ) </title></a>
+  <use id='nn' x='137' y='1107' xlink:href='#nn'/><a xlink:href='#barcode'><use id='idx' x='137' y='1106' xlink:href='#idx'/><title>Index  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='153' y='1117'>barcode</text><title>barcode varchar&#040;2147483647&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='213' y='1106' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+
+<!-- ============= Table 'barcode_exceptions' ============= -->
+<rect class='table' x='330' y='803' width='120' height='60' rx='7' ry='7' />
+<path d='M 330.50 829.50 L 330.50 810.50 Q 330.50 803.50 337.50 803.50 L 442.50 803.50 Q 449.50 803.50 449.50 810.50 L 449.50 829.50 L330.50 829.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#barcode_exceptions'><text x='335' y='817' class='tableTitle'>barcode_exceptions</text><title>Table barcodes.barcode_exceptions</title></a>
+  <use id='nn' x='332' y='837' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='332' y='836' xlink:href='#pk'/><title>Primary Key  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='348' y='847'>barcode</text><title>barcode varchar&#040;100&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='438' y='836' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+
+<!-- ============= Table 'settings' ============= -->
+<rect class='table' x='105' y='638' width='135' height='105' rx='7' ry='7' />
+<path d='M 105.50 664.50 L 105.50 645.50 Q 105.50 638.50 112.50 638.50 L 232.50 638.50 Q 239.50 638.50 239.50 645.50 L 239.50 664.50 L105.50 664.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#settings'><text x='151' y='652' class='tableTitle'>settings</text><title>Table ag.settings</title></a>
+  <a xlink:href='#test_environment'><text x='123' y='682'>test_environment</text><title>test_environment varchar&#040;2147483647&#041;</title></a>
+  <a xlink:href='#base_data_dir'><text x='123' y='697'>base_data_dir</text><title>base_data_dir varchar&#040;2147483647&#041;</title></a>
+  <a xlink:href='#locale'><text x='123' y='712'>locale</text><title>locale varchar&#040;2147483647&#041;</title></a>
+  <use id='nn' x='107' y='717' xlink:href='#nn'/><a xlink:href='#current_patch'><text x='123' y='727'>current_patch</text><title>current_patch varchar&#040;2147483647&#041; not null default &#039;unpatched&#039;&#058;&#058;character varying</title></a>
+
+<!-- ============= Table 'ag_kit_barcodes' ============= -->
+<rect class='table' x='735' y='878' width='180' height='345' rx='7' ry='7' />
+<path d='M 735.50 904.50 L 735.50 885.50 Q 735.50 878.50 742.50 878.50 L 907.50 878.50 Q 914.50 878.50 914.50 885.50 L 914.50 904.50 L735.50 904.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
+<a xlink:href='#ag_kit_barcodes'><text x='781' y='892' class='tableTitle'>ag_kit_barcodes</text><title>Table ag.ag_kit_barcodes</title></a>
+  <use id='nn' x='737' y='912' xlink:href='#nn'/><a xlink:href='#ag_kit_barcode_id'><use id='pk' x='737' y='911' xlink:href='#pk'/><title>Primary Key  ( ag_kit_barcode_id ) </title></a>
+<a xlink:href='#ag_kit_barcode_id'><text x='753' y='922'>ag_kit_barcode_id</text><title>ag_kit_barcode_id uuid not null default ag&#046;uuid&#095;generate&#095;v4&#040;&#041;</title></a>
+  <a xlink:href='#ag_kit_id'><use id='idx' x='737' y='926' xlink:href='#idx'/><title>Index  ( ag_kit_id ) </title></a>
+<a xlink:href='#ag_kit_id'><text x='753' y='937'>ag_kit_id</text><title>ag_kit_id uuid</title></a>
+<a xlink:href='#ag_kit_id'><use id='fk' x='903' y='926' xlink:href='#fk'/><title>References ag_kit ( ag_kit_id ) </title></a>
+  <use id='nn' x='737' y='942' xlink:href='#nn'/><a xlink:href='#barcode'><use id='unq' x='737' y='941' xlink:href='#unq'/><title>Unique Index  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='753' y='952'>barcode</text><title>barcode varchar&#040;2147483647&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='903' y='941' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+  <a xlink:href='#survey_id'><use id='idx' x='737' y='956' xlink:href='#idx'/><title>Index  ( survey_id ) </title></a>
+<a xlink:href='#survey_id'><text x='753' y='967'>survey_id</text><title>survey_id varchar&#040;2147483647&#041;</title></a>
+<a xlink:href='#survey_id'><use id='fk' x='903' y='956' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
+  <a xlink:href='#sample_barcode_file'><text x='753' y='982'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;500&#041;</title></a>
+  <a xlink:href='#sample_barcode_file_md5'><text x='753' y='997'>sample_barcode_file_md5</text><title>sample_barcode_file_md5 varchar&#040;50&#041;</title></a>
+  <a xlink:href='#site_sampled'><text x='753' y='1012'>site_sampled</text><title>site_sampled varchar&#040;200&#041;</title></a>
+  <a xlink:href='#sample_date'><text x='753' y='1027'>sample_date</text><title>sample_date varchar&#040;20&#041;</title></a>
+  <a xlink:href='#participant_name'><text x='753' y='1042'>participant_name</text><title>participant_name varchar&#040;200&#041;</title></a>
+  <a xlink:href='#sample_time'><text x='753' y='1057'>sample_time</text><title>sample_time varchar&#040;100&#041;</title></a>
+  <a xlink:href='#notes'><text x='753' y='1072'>notes</text><title>notes varchar&#040;2000&#041;</title></a>
+  <a xlink:href='#environment_sampled'><text x='753' y='1087'>environment_sampled</text><title>environment_sampled varchar&#040;100&#041;</title></a>
+  <a xlink:href='#moldy'><text x='753' y='1102'>moldy</text><title>moldy char&#040;1&#041;</title></a>
+  <a xlink:href='#overloaded'><text x='753' y='1117'>overloaded</text><title>overloaded char&#040;1&#041;</title></a>
+  <a xlink:href='#other'><text x='753' y='1132'>other</text><title>other char&#040;1&#041;</title></a>
+  <a xlink:href='#other_text'><text x='753' y='1147'>other_text</text><title>other_text varchar&#040;2000&#041;</title></a>
+  <a xlink:href='#date_of_last_email'><text x='753' y='1162'>date_of_last_email</text><title>date_of_last_email varchar&#040;20&#041;</title></a>
+  <a xlink:href='#results_ready'><text x='753' y='1177'>results_ready</text><title>results_ready varchar&#040;1&#041;</title></a>
+  <a xlink:href='#withdrawn'><text x='753' y='1192'>withdrawn</text><title>withdrawn varchar&#040;1&#041;</title></a>
+  <a xlink:href='#refunded'><text x='753' y='1207'>refunded</text><title>refunded varchar&#040;1&#041;</title></a>
+
+<!-- ============= Table 'handout_barcode' ============= -->
+<rect class='table' x='255' y='413' width='150' height='90' rx='7' ry='7' />
+<path d='M 255.50 439.50 L 255.50 420.50 Q 255.50 413.50 262.50 413.50 L 397.50 413.50 Q 404.50 413.50 404.50 420.50 L 404.50 439.50 L255.50 439.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#handout_barcode'><text x='282' y='427' class='tableTitle'>handout_barcode</text><title>Table ag.handout_barcode</title></a>
+  <use id='nn' x='257' y='447' xlink:href='#nn'/><a xlink:href='#kit_id'><use id='pk' x='257' y='446' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) Index  ( kit_id ) </title></a>
+<a xlink:href='#kit_id'><text x='273' y='457'>kit_id</text><title>kit_id varchar&#040;2147483647&#041; not null</title></a>
+<a xlink:href='#kit_id'><use id='fk' x='393' y='446' xlink:href='#fk'/><title>References ag_handout_kits ( kit_id ) </title></a>
+  <use id='nn' x='257' y='462' xlink:href='#nn'/><a xlink:href='#barcode'><use id='pk' x='257' y='461' xlink:href='#pk'/><title>Primary Key  ( kit_id, barcode ) Index  ( barcode ) </title></a>
+<a xlink:href='#barcode'><text x='273' y='472'>barcode</text><title>barcode varchar&#040;9&#041; not null</title></a>
+<a xlink:href='#barcode'><use id='fk' x='393' y='461' xlink:href='#fk'/><title>References barcode ( barcode ) </title></a>
+  <a xlink:href='#sample_barcode_file'><text x='273' y='487'>sample_barcode_file</text><title>sample_barcode_file varchar&#040;13&#041;</title></a>
 
 </g></svg>
 
@@ -1106,7 +1115,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='ag_survery_answer_id'>ag&#095;survery&#095;answer&#095;id</a></td>
-		<td width='40%'> uuid   DEFO uuid_generate_v4() </td>
+		<td width='40%'> uuid   DEFO ag.uuid_generate_v4() </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -1448,7 +1457,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <tbody>
 	<tr>
 		<td><a name='survey_response_type'>survey&#095;response&#095;type</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -1506,12 +1515,12 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='american'>american</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'> The american english version of the question group&#039;s name </td>
 	</tr>
 	<tr>
 		<td><a name='british'>british</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -1538,7 +1547,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <tbody>
 	<tr>
 		<td><a name='ag_kit_id'>ag&#095;kit&#095;id</a></td>
-		<td width='40%'> uuid  NOT NULL  DEFO uuid_generate_v4() </td>
+		<td width='40%'> uuid  NOT NULL  DEFO ag.uuid_generate_v4() </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -1553,7 +1562,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='kit_password'>kit&#095;password</a></td>
-		<td width='40%'> varchar&#040; 50 &#041;   </td>
+		<td width='40%'> varchar&#040; 60 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -1591,6 +1600,11 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 		<td width='40%'> varchar&#040; 1 &#041;   DEFO 'n'::character varying </td>
 		<td width='99%'>  </td>
 	</tr>
+	<tr>
+		<td><a name='open_humans_token'>open&#095;humans&#095;token</a></td>
+		<td width='40%'> varchar&#040; 64 &#041;   </td>
+		<td width='99%'> The Open Humans access token corresponding to the Open Humans user that has authorized data sharing with this kit&#046; </td>
+	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
 	<tr>		<td>ag&#095;kit&#095;pkey primary key</td>
 		<td> ON ag&#095;kit&#095;id</td>
@@ -1622,7 +1636,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <tbody>
 	<tr>
 		<td><a name='survey_id'>survey&#095;id</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -1632,7 +1646,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='response'>response</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -1676,7 +1690,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='triggering_response'>triggering&#095;response</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'> The response to the question that will cause the appearance of the triggered&#095;question </td>
 	</tr>
 	<tr>
@@ -1728,12 +1742,12 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <tbody>
 	<tr>
 		<td><a name='american'>american</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
 		<td><a name='british'>british</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -1762,12 +1776,12 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='response'>response</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
 		<td><a name='display_index'>display&#095;index</a></td>
-		<td width='40%'> serial   </td>
+		<td width='40%'> serial  NOT NULL  </td>
 		<td width='99%'> The display order of this response </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -2377,12 +2391,12 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <tbody>
 	<tr>
 		<td><a name='iso_code'>iso&#095;code</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'> The ISO code for the country </td>
 	</tr>
 	<tr>
 		<td><a name='country'>country</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -2417,7 +2431,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='survey_response_type'>survey&#095;response&#095;type</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -2446,155 +2460,13 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <br/><br/>
 <table id='dbs' >
 <thead>
-<tr><th colspan='3'><a name='ag_kit_barcodes'>ag_kit_barcodes</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='ag_kit_barcode_id'>ag&#095;kit&#095;barcode&#095;id</a></td>
-		<td width='40%'> uuid  NOT NULL  DEFO uuid_generate_v4() </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='ag_kit_id'>ag&#095;kit&#095;id</a></td>
-		<td width='40%'> uuid   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='barcode'>barcode</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='survey_id'>survey&#095;id</a></td>
-		<td width='40%'> varchar   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='sample_barcode_file'>sample&#095;barcode&#095;file</a></td>
-		<td width='40%'> varchar&#040; 500 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='sample_barcode_file_md5'>sample&#095;barcode&#095;file&#095;md5</a></td>
-		<td width='40%'> varchar&#040; 50 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='site_sampled'>site&#095;sampled</a></td>
-		<td width='40%'> varchar&#040; 200 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='sample_date'>sample&#095;date</a></td>
-		<td width='40%'> varchar&#040; 20 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='participant_name'>participant&#095;name</a></td>
-		<td width='40%'> varchar&#040; 200 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='sample_time'>sample&#095;time</a></td>
-		<td width='40%'> varchar&#040; 100 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='notes'>notes</a></td>
-		<td width='40%'> varchar&#040; 2000 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='environment_sampled'>environment&#095;sampled</a></td>
-		<td width='40%'> varchar&#040; 100 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='moldy'>moldy</a></td>
-		<td width='40%'> char&#040; 1 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='overloaded'>overloaded</a></td>
-		<td width='40%'> char&#040; 1 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='other'>other</a></td>
-		<td width='40%'> char&#040; 1 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='other_text'>other&#095;text</a></td>
-		<td width='40%'> varchar&#040; 2000 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='date_of_last_email'>date&#095;of&#095;last&#095;email</a></td>
-		<td width='40%'> varchar&#040; 20 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='results_ready'>results&#095;ready</a></td>
-		<td width='40%'> varchar&#040; 1 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='withdrawn'>withdrawn</a></td>
-		<td width='40%'> varchar&#040; 1 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='refunded'>refunded</a></td>
-		<td width='40%'> varchar&#040; 1 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>ag&#095;kit&#095;barcodes&#095;pkey primary key</td>
-		<td> ON ag&#095;kit&#095;barcode&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>ag&#095;kit&#095;barcodes&#095;barcode&#095;key unique</td>
-		<td> ON barcode</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>ix&#095;ag&#095;kit&#095;bc&#095;kit </td>
-		<td> ON ag&#095;kit&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;ag&#095;kit&#095;barcodes </td>
-		<td> ON survey&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
-	<tr>
-		<td>fk_ag_kit_barcodes</td>
-		<td > ( ag&#095;kit&#095;id ) ref <a href='#ag&#095;kit'>ag&#095;kit</a> (ag&#095;kit&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_ag_kit_barcodes_0</td>
-		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_ag_kit_barcodes_1</td>
-		<td > ( survey&#095;id ) ref <a href='#ag&#095;login&#095;surveys'>ag&#095;login&#095;surveys</a> (survey&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
 <tr><th colspan='3'><a name='promoted_survey_ids'>promoted_survey_ids</a></th></tr>
 <tr><td colspan='3'>Keeps track of the survey&#095;ids that correspond to surveys that were ported from first questionnaire to the second </td></tr>
 </thead>
 <tbody>
 	<tr>
 		<td><a name='survey_id'>survey&#095;id</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -2625,17 +2497,17 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='question_shortname'>question&#095;shortname</a></td>
-		<td width='40%'> varchar&#040; 100 &#041;  NOT NULL  DEFO 'TODO' </td>
+		<td width='40%'> varchar&#040; 100 &#041;  NOT NULL  </td>
 		<td width='99%'> A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown </td>
 	</tr>
 	<tr>
 		<td><a name='american'>american</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'> The american english version of the question </td>
 	</tr>
 	<tr>
 		<td><a name='british'>british</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'> The british english version of the question </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -2666,7 +2538,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <tbody>
 	<tr>
 		<td><a name='ag_login_id'>ag&#095;login&#095;id</a></td>
-		<td width='40%'> uuid  NOT NULL  DEFO uuid_generate_v4() </td>
+		<td width='40%'> uuid  NOT NULL  DEFO ag.uuid_generate_v4() </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -2740,22 +2612,22 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <tbody>
 	<tr>
 		<td><a name='zipcode'>zipcode</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
 		<td><a name='state'>state</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
 		<td><a name='fips_regions'>fips&#095;regions</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
 		<td><a name='city'>city</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -2804,7 +2676,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='participant_email'>participant&#095;email</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -2844,12 +2716,12 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='assent_obtainer'>assent&#095;obtainer</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
 		<td><a name='age_range'>age&#095;range</a></td>
-		<td width='40%'> varchar   </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -2980,12 +2852,359 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <br/><br/>
 <table id='dbs' >
 <thead>
+<tr><th colspan='3'><a name='ag_map_markers'>ag_map_markers</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='zipcode'>zipcode</a></td>
+		<td width='40%'> varchar&#040; 20 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='latitude'>latitude</a></td>
+		<td width='40%'> float8   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='longitude'>longitude</a></td>
+		<td width='40%'> float8   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='marker_color'>marker&#095;color</a></td>
+		<td width='40%'> varchar&#040; 10 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='order_by'>order&#095;by</a></td>
+		<td width='40%'> bigint   </td>
+		<td width='99%'>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='ag_handout_kits'>ag_handout_kits</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='kit_id'>kit&#095;id</a></td>
+		<td width='40%'> varchar&#040; 9 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='password'>password</a></td>
+		<td width='40%'> varchar&#040; 60 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='verification_code'>verification&#095;code</a></td>
+		<td width='40%'> varchar&#040; 5 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='swabs_per_kit'>swabs&#095;per&#095;kit</a></td>
+		<td width='40%'> bigint   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='print_results'>print&#095;results</a></td>
+		<td width='40%'> varchar&#040; 1 &#041;   DEFO 'n'::character varying </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='created_on'>created&#095;on</a></td>
+		<td width='40%'> timestamp  NOT NULL  DEFO current_timestamp </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>ag&#095;handout&#095;kits&#095;pkey primary key</td>
+		<td> ON kit&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='ag_login_surveys'>ag_login_surveys</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='ag_login_id'>ag&#095;login&#095;id</a></td>
+		<td width='40%'> uuid  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='survey_id'>survey&#095;id</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='participant_name'>participant&#095;name</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='vioscreen_status'>vioscreen&#095;status</a></td>
+		<td width='40%'> integer   </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>pk&#095;ag&#095;login&#095;surveys primary key</td>
+		<td> ON survey&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;ag&#095;login&#095;surveys </td>
+		<td> ON participant&#095;name</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;ag&#095;login&#095;surveys&#095;0 </td>
+		<td> ON ag&#095;login&#095;id&#044; participant&#095;name</td>
+		<td>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
+	<tr>
+		<td>fk_ag_login_surveys</td>
+		<td > ( ag&#095;login&#095;id ) ref <a href='#ag&#095;login'>ag&#095;login</a> (ag&#095;login&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_ag_login_surveys0</td>
+		<td > ( ag&#095;login&#095;id&#044; participant&#095;name ) ref <a href='#ag&#095;consent'>ag&#095;consent</a> (ag&#095;login&#095;id&#044; participant&#095;name) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='survey_answers'>survey_answers</a></th></tr>
+<tr><td colspan='3'>Stores answers to questions of type SINGLE and MULTIPLE </td></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='survey_id'>survey&#095;id</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
+		<td width='99%'> The unique identifier for the survey </td>
+	</tr>
+	<tr>
+		<td><a name='survey_question_id'>survey&#095;question&#095;id</a></td>
+		<td width='40%'> bigint  NOT NULL  </td>
+		<td width='99%'> The question being answered </td>
+	</tr>
+	<tr>
+		<td><a name='response'>response</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
+		<td width='99%'> The answer the question being asked </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>pk&#095;survey&#095;answers primary key</td>
+		<td> ON survey&#095;id&#044; survey&#095;question&#095;id&#044; response</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;survey&#095;answers </td>
+		<td> ON survey&#095;question&#095;id&#044; response</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;survey&#095;answers&#095;0 </td>
+		<td> ON survey&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
+	<tr>
+		<td>fk_survey_answers</td>
+		<td > ( survey&#095;question&#095;id&#044; response ) ref <a href='#survey&#095;question&#095;response'>survey&#095;question&#095;response</a> (survey&#095;question&#095;id&#044; response) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_survey_answers_0</td>
+		<td > ( survey&#095;id ) ref <a href='#ag&#095;login&#095;surveys'>ag&#095;login&#095;surveys</a> (survey&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='external_survey_answers'>external_survey_answers</a></th></tr>
+<tr><td colspan='3'>This stores answers to third party surveys in JSON format&#044; keyed to the original survey ID </td></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='survey_id'>survey&#095;id</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='external_survey_id'>external&#095;survey&#095;id</a></td>
+		<td width='40%'> bigint  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='pulldown_date'>pulldown&#095;date</a></td>
+		<td width='40%'> date  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='answers'>answers</a></td>
+		<td width='40%'> json  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>pk&#095;third&#095;party&#095;surveys primary key</td>
+		<td> ON survey&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;external&#095;survey </td>
+		<td> ON external&#095;survey&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
+	<tr>
+		<td>fk_third_party_surveys</td>
+		<td > ( survey&#095;id ) ref <a href='#ag&#095;login&#095;surveys'>ag&#095;login&#095;surveys</a> (survey&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_external_survey</td>
+		<td > ( external&#095;survey&#095;id ) ref <a href='#external&#095;survey'>external&#095;survey</a> (external&#095;survey&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='external_survey'>external_survey</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='external_survey_id'>external&#095;survey&#095;id</a></td>
+		<td width='40%'> bigserial  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='external_survey'>external&#095;survey</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='external_survey_description'>external&#095;survey&#095;description</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>pk&#095;external&#095;surveys primary key</td>
+		<td> ON external&#095;survey&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='plate'>plate</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='plate_id'>plate&#095;id</a></td>
+		<td width='40%'> bigint  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='plate'>plate</a></td>
+		<td width='40%'> varchar&#040; 50 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='sequence_date'>sequence&#095;date</a></td>
+		<td width='40%'> varchar&#040; 20 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>plate&#095;pkey primary key</td>
+		<td> ON plate&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='project_barcode'>project_barcode</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='project_id'>project&#095;id</a></td>
+		<td width='40%'> bigint  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='barcode'>barcode</a></td>
+		<td width='40%'> char&#040; 9 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>project&#095;barcode&#095;pkey primary key</td>
+		<td> ON project&#095;id&#044; barcode</td>
+		<td>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
+	<tr>
+		<td>fk_pb_to_barcode</td>
+		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_pb_to_project</td>
+		<td > ( project&#095;id ) ref <a href='#project'>project</a> (project&#095;id) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='project'>project</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='project_id'>project&#095;id</a></td>
+		<td width='40%'> bigint  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='project'>project</a></td>
+		<td width='40%'> varchar&#040; 1000 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>project&#095;pkey primary key</td>
+		<td> ON project&#095;id</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
 <tr><th colspan='3'><a name='barcode'>barcode</a></th></tr>
 </thead>
 <tbody>
 	<tr>
 		<td><a name='barcode'>barcode</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -3034,70 +3253,6 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <br/><br/>
 <table id='dbs' >
 <thead>
-<tr><th colspan='3'><a name='project_barcode'>project_barcode</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='project_id'>project&#095;id</a></td>
-		<td width='40%'> bigint  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='barcode'>barcode</a></td>
-		<td width='40%'> char&#040; 9 &#041;  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>project&#095;barcode&#095;pkey primary key</td>
-		<td> ON project&#095;id&#044; barcode</td>
-		<td>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
-	<tr>
-		<td>fk_pb_to_barcode</td>
-		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_pb_to_project</td>
-		<td > ( project&#095;id ) ref <a href='#project'>project</a> (project&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='plate'>plate</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='plate_id'>plate&#095;id</a></td>
-		<td width='40%'> bigint  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='plate'>plate</a></td>
-		<td width='40%'> varchar&#040; 50 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='sequence_date'>sequence&#095;date</a></td>
-		<td width='40%'> varchar&#040; 20 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>plate&#095;pkey primary key</td>
-		<td> ON plate&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
 <tr><th colspan='3'><a name='plate_barcode'>plate_barcode</a></th></tr>
 </thead>
 <tbody>
@@ -3108,7 +3263,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='barcode'>barcode</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -3129,30 +3284,6 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	<tr>
 		<td>fk_plate_barcode_0</td>
 		<td > ( plate&#095;id ) ref <a href='#plate'>plate</a> (plate&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='project'>project</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='project_id'>project&#095;id</a></td>
-		<td width='40%'> bigint  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='project'>project</a></td>
-		<td width='40%'> varchar&#040; 1000 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>project&#095;pkey primary key</td>
-		<td> ON project&#095;id</td>
 		<td>  </td>
 	</tr>
 </tbody>
@@ -3186,33 +3317,170 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <br/><br/>
 <table id='dbs' >
 <thead>
-<tr><th colspan='3'><a name='ag_map_markers'>ag_map_markers</a></th></tr>
+<tr><th colspan='3'><a name='settings'>settings</a></th></tr>
 </thead>
 <tbody>
 	<tr>
-		<td><a name='zipcode'>zipcode</a></td>
+		<td><a name='test_environment'>test&#095;environment</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='base_data_dir'>base&#095;data&#095;dir</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='locale'>locale</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='current_patch'>current&#095;patch</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  DEFO 'unpatched'::character varying </td>
+		<td width='99%'>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='ag_kit_barcodes'>ag_kit_barcodes</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='ag_kit_barcode_id'>ag&#095;kit&#095;barcode&#095;id</a></td>
+		<td width='40%'> uuid  NOT NULL  DEFO ag.uuid_generate_v4() </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='ag_kit_id'>ag&#095;kit&#095;id</a></td>
+		<td width='40%'> uuid   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='barcode'>barcode</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='survey_id'>survey&#095;id</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='sample_barcode_file'>sample&#095;barcode&#095;file</a></td>
+		<td width='40%'> varchar&#040; 500 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='sample_barcode_file_md5'>sample&#095;barcode&#095;file&#095;md5</a></td>
+		<td width='40%'> varchar&#040; 50 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='site_sampled'>site&#095;sampled</a></td>
+		<td width='40%'> varchar&#040; 200 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='sample_date'>sample&#095;date</a></td>
 		<td width='40%'> varchar&#040; 20 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
-		<td><a name='latitude'>latitude</a></td>
-		<td width='40%'> float8   </td>
+		<td><a name='participant_name'>participant&#095;name</a></td>
+		<td width='40%'> varchar&#040; 200 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
-		<td><a name='longitude'>longitude</a></td>
-		<td width='40%'> float8   </td>
+		<td><a name='sample_time'>sample&#095;time</a></td>
+		<td width='40%'> varchar&#040; 100 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
-		<td><a name='marker_color'>marker&#095;color</a></td>
-		<td width='40%'> varchar&#040; 10 &#041;   </td>
+		<td><a name='notes'>notes</a></td>
+		<td width='40%'> varchar&#040; 2000 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
-		<td><a name='order_by'>order&#095;by</a></td>
-		<td width='40%'> bigint   </td>
+		<td><a name='environment_sampled'>environment&#095;sampled</a></td>
+		<td width='40%'> varchar&#040; 100 &#041;   </td>
 		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='moldy'>moldy</a></td>
+		<td width='40%'> char&#040; 1 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='overloaded'>overloaded</a></td>
+		<td width='40%'> char&#040; 1 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='other'>other</a></td>
+		<td width='40%'> char&#040; 1 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='other_text'>other&#095;text</a></td>
+		<td width='40%'> varchar&#040; 2000 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='date_of_last_email'>date&#095;of&#095;last&#095;email</a></td>
+		<td width='40%'> varchar&#040; 20 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='results_ready'>results&#095;ready</a></td>
+		<td width='40%'> varchar&#040; 1 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='withdrawn'>withdrawn</a></td>
+		<td width='40%'> varchar&#040; 1 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='refunded'>refunded</a></td>
+		<td width='40%'> varchar&#040; 1 &#041;   </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>ag&#095;kit&#095;barcodes&#095;pkey primary key</td>
+		<td> ON ag&#095;kit&#095;barcode&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>ag&#095;kit&#095;barcodes&#095;barcode&#095;key unique</td>
+		<td> ON barcode</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>ix&#095;ag&#095;kit&#095;bc&#095;kit </td>
+		<td> ON ag&#095;kit&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;ag&#095;kit&#095;barcodes </td>
+		<td> ON survey&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
+	<tr>
+		<td>fk_ag_kit_barcodes</td>
+		<td > ( ag&#095;kit&#095;id ) ref <a href='#ag&#095;kit'>ag&#095;kit</a> (ag&#095;kit&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_ag_kit_barcodes_1</td>
+		<td > ( survey&#095;id ) ref <a href='#ag&#095;login&#095;surveys'>ag&#095;login&#095;surveys</a> (survey&#095;id) </td>
+		<td>  </td>
+	</tr>
+	<tr>
+		<td>fk_ag_kit_barcodes_barcode</td>
+		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
+		<td>  </td>
 	</tr>
 </tbody>
 </table>
@@ -3225,7 +3493,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 <tbody>
 	<tr>
 		<td><a name='kit_id'>kit&#095;id</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;  NOT NULL  </td>
 		<td width='99%'>  </td>
 	</tr>
 	<tr>
@@ -3235,7 +3503,7 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 	<tr>
 		<td><a name='sample_barcode_file'>sample&#095;barcode&#095;file</a></td>
-		<td width='40%'> varchar&#040; 13 &#041;  NOT NULL  </td>
+		<td width='40%'> varchar&#040; 13 &#041;   </td>
 		<td width='99%'>  </td>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
@@ -3253,238 +3521,13 @@ Referred by external_survey_answers ( external_survey_id ) </title></a>
 	</tr>
 <tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
 	<tr>
-		<td>fk_handout_barcode</td>
-		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
-		<td>  </td>
-	</tr>
-	<tr>
 		<td>fk_handout_barcode_0</td>
 		<td > ( kit&#095;id ) ref <a href='#ag&#095;handout&#095;kits'>ag&#095;handout&#095;kits</a> (kit&#095;id) </td>
 		<td>  </td>
 	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='ag_handout_kits'>ag_handout_kits</a></th></tr>
-</thead>
-<tbody>
 	<tr>
-		<td><a name='kit_id'>kit&#095;id</a></td>
-		<td width='40%'> varchar&#040; 9 &#041;  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='password'>password</a></td>
-		<td width='40%'> varchar&#040; 11 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='verification_code'>verification&#095;code</a></td>
-		<td width='40%'> varchar&#040; 5 &#041;   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='swabs_per_kit'>swabs&#095;per&#095;kit</a></td>
-		<td width='40%'> bigint   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='print_results'>print&#095;results</a></td>
-		<td width='40%'> varchar&#040; 1 &#041;   DEFO 'n'::character varying </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='created_on'>created&#095;on</a></td>
-		<td width='40%'> timestamp  NOT NULL  DEFO current_timestamp </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>pk&#095;ag&#095;handout&#095;kits primary key</td>
-		<td> ON kit&#095;id</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='ag_login_surveys'>ag_login_surveys</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='ag_login_id'>ag&#095;login&#095;id</a></td>
-		<td width='40%'> uuid  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='survey_id'>survey&#095;id</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='participant_name'>participant&#095;name</a></td>
-		<td width='40%'> varchar   </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='vioscreen_status'>vioscreen&#095;status</a></td>
-		<td width='40%'> integer   </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>pk&#095;ag&#095;login&#095;surveys primary key</td>
-		<td> ON survey&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;ag&#095;login&#095;surveys </td>
-		<td> ON participant&#095;name</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;ag&#095;login&#095;surveys&#095;0 </td>
-		<td> ON ag&#095;login&#095;id&#044; participant&#095;name</td>
-		<td>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
-	<tr>
-		<td>fk_ag_login_surveys</td>
-		<td > ( ag&#095;login&#095;id ) ref <a href='#ag&#095;login'>ag&#095;login</a> (ag&#095;login&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_ag_login_surveys0</td>
-		<td > ( ag&#095;login&#095;id&#044; participant&#095;name ) ref <a href='#ag&#095;consent'>ag&#095;consent</a> (ag&#095;login&#095;id&#044; participant&#095;name) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='survey_answers'>survey_answers</a></th></tr>
-<tr><td colspan='3'>Stores answers to questions of type SINGLE and MULTIPLE </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='survey_id'>survey&#095;id</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
-		<td width='99%'> The unique identifier for the survey </td>
-	</tr>
-	<tr>
-		<td><a name='survey_question_id'>survey&#095;question&#095;id</a></td>
-		<td width='40%'> bigint  NOT NULL  </td>
-		<td width='99%'> The question being answered </td>
-	</tr>
-	<tr>
-		<td><a name='response'>response</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
-		<td width='99%'> The answer the question being asked </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>pk&#095;survey&#095;answers primary key</td>
-		<td> ON survey&#095;id&#044; survey&#095;question&#095;id&#044; response</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;survey&#095;answers </td>
-		<td> ON survey&#095;question&#095;id&#044; response</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;survey&#095;answers&#095;0 </td>
-		<td> ON survey&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
-	<tr>
-		<td>fk_survey_answers</td>
-		<td > ( survey&#095;question&#095;id&#044; response ) ref <a href='#survey&#095;question&#095;response'>survey&#095;question&#095;response</a> (survey&#095;question&#095;id&#044; response) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_survey_answers_0</td>
-		<td > ( survey&#095;id ) ref <a href='#ag&#095;login&#095;surveys'>ag&#095;login&#095;surveys</a> (survey&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='external_survey_answers'>external_survey_answers</a></th></tr>
-<tr><td colspan='3'>This stores answers to third party surveys in JSON format&#044; keyed to the original survey ID </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='survey_id'>survey&#095;id</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='external_survey_id'>external&#095;survey&#095;id</a></td>
-		<td width='40%'> bigint  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='pulldown_date'>pulldown&#095;date</a></td>
-		<td width='40%'> date  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='answers'>answers</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>pk&#095;third&#095;party&#095;surveys primary key</td>
-		<td> ON survey&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;external&#095;survey </td>
-		<td> ON external&#095;survey&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
-	<tr>
-		<td>fk_third_party_surveys</td>
-		<td > ( survey&#095;id ) ref <a href='#ag&#095;login&#095;surveys'>ag&#095;login&#095;surveys</a> (survey&#095;id) </td>
-		<td>  </td>
-	</tr>
-	<tr>
-		<td>fk_external_survey</td>
-		<td > ( external&#095;survey&#095;id ) ref <a href='#external&#095;survey'>external&#095;survey</a> (external&#095;survey&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='external_survey'>external_survey</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='external_survey_id'>external&#095;survey&#095;id</a></td>
-		<td width='40%'> bigserial  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='external_survey'>external&#095;survey</a></td>
-		<td width='40%'> varchar  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='external_survey_description'>external&#095;survey&#095;description</a></td>
-		<td width='40%'> varchar   </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>pk&#095;external&#095;surveys primary key</td>
-		<td> ON external&#095;survey&#095;id</td>
+		<td>fk_handout_barcode_barcode</td>
+		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/amgut/db/initialize.sql
+++ b/amgut/db/initialize.sql
@@ -1,4 +1,4 @@
-SET search_path TO ag, public;
+SET search_path TO ag, public, barcodes;
 ----------------------------------------------------------
 -- survey_group
 ----------------------------------------------------------

--- a/amgut/db/initialize.sql
+++ b/amgut/db/initialize.sql
@@ -1,4 +1,4 @@
-SET search_path TO ag, public, barcodes;
+SET search_path TO ag, barcodes, public;
 ----------------------------------------------------------
 -- survey_group
 ----------------------------------------------------------

--- a/amgut/db/patches/0011.sql
+++ b/amgut/db/patches/0011.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA barcodes;
+
+ALTER TABLE ag.barcode SET SCHEMA barcodes;
+ALTER TABLE ag.project SET SCHEMA barcodes;
+ALTER TABLE ag.project_barcode SET SCHEMA barcodes;
+ALTER TABLE ag.plate SET SCHEMA barcodes;
+ALTER TABLE ag.barcode_exceptions SET SCHEMA barcodes;
+ALTER TABLE ag.plate_barcode SET SCHEMA barcodes;

--- a/amgut/db/patches/0011.sql
+++ b/amgut/db/patches/0011.sql
@@ -6,3 +6,6 @@ ALTER TABLE ag.project_barcode SET SCHEMA barcodes;
 ALTER TABLE ag.plate SET SCHEMA barcodes;
 ALTER TABLE ag.barcode_exceptions SET SCHEMA barcodes;
 ALTER TABLE ag.plate_barcode SET SCHEMA barcodes;
+
+--Do not allow null participant names
+ALTER TABLE ag.ag_login_surveys ALTER COLUMN participant_name SET NOT NULL;

--- a/amgut/db/populate_test.sql
+++ b/amgut/db/populate_test.sql
@@ -1,5 +1,5 @@
 -- Populates the test database
-SET search_path TO ag, public;
+SET search_path TO ag, public, barcodes;
 
 INSERT INTO ag_login (
   ag_login_id,

--- a/amgut/db/populate_test.sql
+++ b/amgut/db/populate_test.sql
@@ -1,5 +1,5 @@
 -- Populates the test database
-SET search_path TO ag, public, barcodes;
+SET search_path TO ag, barcodes, public;
 
 INSERT INTO ag_login (
   ag_login_id,

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -82,7 +82,7 @@ class AGDataAccess(object):
         else:
             self.connection = con
         cur = self.get_cursor()
-        cur.execute('set search_path to ag, public')
+        cur.execute('set search_path to ag, public, barcodes')
 
         self._sql = SQLConnectionHandler(con)
 

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -82,7 +82,7 @@ class AGDataAccess(object):
         else:
             self.connection = con
         cur = self.get_cursor()
-        cur.execute('set search_path to ag, public, barcodes')
+        cur.execute('set search_path TO ag, barcodes, public')
 
         self._sql = SQLConnectionHandler(con)
 

--- a/amgut/lib/data_access/sql_connection.py
+++ b/amgut/lib/data_access/sql_connection.py
@@ -23,7 +23,7 @@ class SQLConnectionHandler(object):
         else:
             self._connection = con
 
-        self.execute('SET search_path TO ag, public, barcodes')
+        self.execute('SET search_path TO ag, barcodes, public')
 
     def __del__(self):
         self._connection.close()

--- a/amgut/lib/data_access/sql_connection.py
+++ b/amgut/lib/data_access/sql_connection.py
@@ -23,7 +23,7 @@ class SQLConnectionHandler(object):
         else:
             self._connection = con
 
-        self.execute('SET search_path TO ag, public')
+        self.execute('SET search_path TO ag, public, barcodes')
 
     def __del__(self):
         self._connection.close()


### PR DESCRIPTION
Depends on #429

This moves the barcode table and associated tables to their own schema, keeping the foreign keys from the ag schema. 