### PR TITLE
Break out secondary survey links for better readability

### DIFF
--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -939,8 +939,8 @@ _HUMAN_SURVEY_COMPLETED = {
     'COMPLETED_HEADER': 'Congratulations!',
     'COMPLETED_TEXT': 'You are now an enrolled participant in the %(PROJECT_TITLE)s!' % media_locale,
     'AVAILABLE_SURVEYS': 'Below are a few additional surveys that you may be interested in completing. There is no requirement to take these surveys, and your decision does not affect your involvement in the project in any way.',
-    'SURVEY_ASD': '<a href="http://www.anl.gov/contributors/jack-gilbert">Dr. Jack Gilbert</a> is exploring the relationship between gut dysbiosis and Autism Spectrum Disorders, and in conjunction with the American Gut Project, we started an ASD-Cohort study. This additional survey contains questions specific to that cohort, but it is open to any participant to take if they so choose. Please click <a href="%s">here</a> to take the ASD-Cohort survey.',
-    'SURVEY_VIOSCREEN': 'The American Gut Project and its sister projects are very interested in diet. If you\'d like to provide additional detail about your diet, please click <a href="%s">here</a> to take a detailed diet survey (known as an Food Frequency Questionnaire). This is a validated FFQ, and is the one used by the Mayo Clinic.'
+    'SURVEY_ASD': '<h3 style="text-align: center"><a href="%s">ASD-Cohort survey</a></h3><a href="http://www.anl.gov/contributors/jack-gilbert">Dr. Jack Gilbert</a> is exploring the relationship between gut dysbiosis and Autism Spectrum Disorders, and in conjunction with the American Gut Project, we started an ASD-Cohort study. This additional survey contains questions specific to that cohort, but it is open to any participant to take if they so choose.',
+    'SURVEY_VIOSCREEN': '<h3 style="text-align: center"><a href="%s">Dietary Survey</a></h3>The American Gut Project and its sister projects are very interested in diet. If you\'d like to provide additional detail about your diet, please click the link above to take a detailed diet survey (known as an Food Frequency Questionnaire). This is a validated FFQ, and is the one used by the Mayo Clinic.'
 }
 
 _SURVEY_MAIN = {

--- a/amgut/lib/locale_data/british_gut.py
+++ b/amgut/lib/locale_data/british_gut.py
@@ -924,8 +924,8 @@ _HUMAN_SURVEY_COMPLETED = {
     'COMPLETED_HEADER': 'Congratulations!',
     'COMPLETED_TEXT': 'You are now an enrolled participant in the %(PROJECT_TITLE)s!' % media_locale,
     'AVAILABLE_SURVEYS': 'Below are a few additional surveys that you may be interested in completing. There is no requirement to take these surveys, and your decision does not affect your involvement in the project in any way.',
-    'SURVEY_ASD': '<a href="http://www.anl.gov/contributors/jack-gilbert">Dr. Jack Gilbert</a> is exploring the relationship between gut dysbiosis and Autism Spectrum Disorders, and in conjunction with the British Gut Project, we started an ASD-Cohort study. This additional survey contains questions specific to that cohort, but it is open to any participant to take if they so choose. Please click <a href="%s">here</a> to take the ASD-Cohort survey.',
-    'SURVEY_VIOSCREEN': 'The British Gut Project and its sister projects are very interested in diet. If you\'d like to provide additional detail about your diet, please click <a href="%s">here</a> to take a detailed diet survey (known as an Food Frequency Questionnaire). This is a validated FFQ, and is the one used by the Mayo Clinic.'
+    'SURVEY_ASD': '<h3 style="text-align: center"><a href="%s">ASD-Cohort survey</a></h3><a href="http://www.anl.gov/contributors/jack-gilbert">Dr. Jack Gilbert</a> is exploring the relationship between gut dysbiosis and Autism Spectrum Disorders, and in conjunction with the British Gut Project, we started an ASD-Cohort study. This additional survey contains questions specific to that cohort, but it is open to any participant to take if they so choose.',
+    'SURVEY_VIOSCREEN': '<h3 style="text-align: center"><a href="%s">Dietary Survey</a></h3>The British Gut Project and its sister projects are very interested in diet. If you\'d like to provide additional detail about your diet, please click above to take a detailed diet survey (known as an Food Frequency Questionnaire). This is a validated FFQ, and is the one used by the Mayo Clinic.'
 }
 
 _NOJS = {

--- a/amgut/templates/human_survey_completed.html
+++ b/amgut/templates/human_survey_completed.html
@@ -2,18 +2,17 @@
 {% block content %}
 {% from amgut import text_locale, media_locale %}
 {% set tl = text_locale['human_survey_completed.html'] %}
-
 <h2>{% raw tl['COMPLETED_HEADER'] %}</h2>
+<div style="text-align: left; padding-left: 10px; padding-right: 10px">
 <p>{% raw tl['COMPLETED_TEXT'] %}</p>
 <p>{% raw tl['AVAILABLE_SURVEYS'] %}</p>
 
 {% for payload in surveys %}
     <p>{% raw payload %}</p>
 {% end %}
-
+</div>
 <form action='{% raw media_locale["SITEBASE"] %}/authed/human_survey_completed/' id="human_survey_completed" method="POST">
     <input type="hidden" name="go_home" value="Done">
     <input type="submit" value="Back to portal"></td>
 </form>
-
 {% end %}


### PR DESCRIPTION
See screenshot. Hopefully more people will take the secondary surveys if the links are more easily picked up on.

<img width="1316" alt="screen shot 2015-07-24 at 2 27 48 pm" src="https://cloud.githubusercontent.com/assets/3079066/8884977/55ae04ba-3210-11e5-99ef-b3a356ab788c.png">
