### PR TITLE
Update patch for ag and public schemas

### DIFF
--- a/amgut/db/patches/0015.sql
+++ b/amgut/db/patches/0015.sql
@@ -1,5 +1,5 @@
 -- August 12, 2015
 -- Update privs for ag_wwwuser
 GRANT USAGE ON SCHEMA barcodes TO "ag_wwwuser";
-GRANT INSERT, UPDATE, DELETE, SELECT ON ALL TABLES IN SCHEMA barcodes TO "ag_wwwuser";
-GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA barcodes TO "ag_wwwuser";
+GRANT INSERT, UPDATE, DELETE, SELECT ON ALL TABLES IN SCHEMA ag, public, barcodes TO "ag_wwwuser";
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA ag, public, barcodes TO "ag_wwwuser";


### PR DESCRIPTION
Since new ag_handout_barcodes table was added to the ag schema, we need to update ag schema permissions as well.