### PR TITLE
fix broken drop_test command

### DIFF
--- a/scripts/ag
+++ b/scripts/ag
@@ -20,7 +20,7 @@ from amgut.connections import ag_data, redis
 from amgut.lib.config_manager import AMGUT_CONFIG
 from amgut.lib.data_access.env_management import (
     create_database, build_and_initialize, make_settings_table, patch_db,
-    populate_test_db, drop_test)
+    populate_test_db, drop_test as drop_test_inner)
 
 
 @click.group()
@@ -79,7 +79,7 @@ def make(db, force):
               help='force removal')
 def drop_test(force):
     """Drops the test database, schema, and role."""
-    drop_test(verbose=True)
+    drop_test_inner(force=force, verbose=True)
 
 
 @cli.command()


### PR DESCRIPTION
just noticed this was broken when I went to apply the new patches to my very old test database.