### PR TITLE
Migrate old unmappable questions

### DIFF
--- a/amgut/db/ag.dbs
+++ b/amgut/db/ag.dbs
@@ -649,6 +649,20 @@
 				<fk_column name="survey_response_type" pk="survey_response_type" />
 			</fk>
 		</table>
+		<table name="survey_question_retired" >
+			<column name="survey_id" type="bigint" jt="-5" mandatory="y" />
+			<column name="survey_question_id" type="bigint" jt="-5" mandatory="y" />
+			<index name="pk_survey_question_retired" unique="PRIMARY_KEY" >
+				<column name="survey_id" />
+				<column name="survey_question_id" />
+			</index>
+			<index name="idx_survey_question_retired" unique="NORMAL" >
+				<column name="survey_question_id" />
+			</index>
+			<fk name="fk_survey_question_retired" to_schema="ag" to_table="survey_question" >
+				<fk_column name="survey_question_id" pk="survey_question_id" />
+			</fk>
+		</table>
 		<table name="survey_question_triggers" >
 			<comment>Which question/answer combos trigger other questions</comment>
 			<column name="survey_question_id" type="bigint" jt="-5" >
@@ -22531,7 +22545,6 @@ AS $function$xpath_exists$function$
 		<entity schema="ag" name="iso_country_lookup" color="ffffff" x="900" y="1620" />
 		<entity schema="ag" name="survey_question_response_type" color="ffcccc" x="690" y="1725" />
 		<entity schema="ag" name="promoted_survey_ids" color="a8c4ef" x="1425" y="915" />
-		<entity schema="ag" name="survey_question" color="a8c4ef" x="420" y="1530" />
 		<entity schema="ag" name="ag_login" color="f7e2c6" x="705" y="405" />
 		<entity schema="ag" name="zipcodes" color="c6c6f7" x="1095" y="45" />
 		<entity schema="ag" name="ag_consent" color="c6d9f7" x="1440" y="675" />
@@ -22553,6 +22566,8 @@ AS $function$xpath_exists$function$
 		<entity schema="barcodes" name="project" color="a8c4ef" x="345" y="885" />
 		<entity schema="barcodes" name="barcode" color="a8c4ef" x="105" y="870" />
 		<entity schema="ag" name="ag_kit_barcodes" color="f7e2c6" x="735" y="885" />
+		<entity schema="ag" name="survey_question" color="a8c4ef" x="420" y="1530" />
+		<entity schema="ag" name="survey_question_retired" color="a8c4ef" x="405" y="1665" />
 		<group name="ag_survey_multiples" color="faf6f0" >
 			<comment>Used by : 
    american_gut_consent</comment>

--- a/amgut/db/ag.dbs
+++ b/amgut/db/ag.dbs
@@ -588,6 +588,10 @@
 			<column name="survey_question_id" type="bigint" jt="-5" mandatory="y" >
 				<comment><![CDATA[The unique question ID]]></comment>
 			</column>
+			<column name="retired" type="bool" jt="-7" >
+				<defo>&#039;F&#039;</defo>
+				<comment><![CDATA[Whether the question is shown or not]]></comment>
+			</column>
 			<column name="question_shortname" type="varchar" length="100" jt="12" mandatory="y" >
 				<comment><![CDATA[A QIIME mapping file-compatible header that describes the question and can be used for metadata pulldown]]></comment>
 			</column>
@@ -647,20 +651,6 @@
 			</fk>
 			<fk name="fk_human_survey_question_response_type" to_schema="ag" to_table="survey_response_types" >
 				<fk_column name="survey_response_type" pk="survey_response_type" />
-			</fk>
-		</table>
-		<table name="survey_question_retired" >
-			<column name="survey_id" type="bigint" jt="-5" mandatory="y" />
-			<column name="survey_question_id" type="bigint" jt="-5" mandatory="y" />
-			<index name="pk_survey_question_retired" unique="PRIMARY_KEY" >
-				<column name="survey_id" />
-				<column name="survey_question_id" />
-			</index>
-			<index name="idx_survey_question_retired" unique="NORMAL" >
-				<column name="survey_question_id" />
-			</index>
-			<fk name="fk_survey_question_retired" to_schema="ag" to_table="survey_question" >
-				<fk_column name="survey_question_id" pk="survey_question_id" />
 			</fk>
 		</table>
 		<table name="survey_question_triggers" >
@@ -22567,7 +22557,6 @@ AS $function$xpath_exists$function$
 		<entity schema="barcodes" name="barcode" color="a8c4ef" x="105" y="870" />
 		<entity schema="ag" name="ag_kit_barcodes" color="f7e2c6" x="735" y="885" />
 		<entity schema="ag" name="survey_question" color="a8c4ef" x="420" y="1530" />
-		<entity schema="ag" name="survey_question_retired" color="a8c4ef" x="405" y="1665" />
 		<group name="ag_survey_multiples" color="faf6f0" >
 			<comment>Used by : 
    american_gut_consent</comment>

--- a/amgut/db/ag.html
+++ b/amgut/db/ag.html
@@ -397,12 +397,7 @@
 	ag_kit_barcodes references barcode ( barcode )</title>
 </path>
 <text x='678' y='940' transform='rotate(0 678,940)' title='Foreign Key fk_ag_kit_barcodes_barcode
-	ag_kit_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 555 1710 L 577,1710 Q 585,1710 585,1702 L 585,1695' >
-	<title>Foreign Key fk_survey_question_retired
-	survey_question_retired references survey_question ( survey_question_id )</title>
-</path>
-<text x='562' y='1705' transform='rotate(0 562,1705)' title='Foreign Key fk_survey_question_retired
-	survey_question_retired references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><!-- ============= Table 'ag_survey_answer' ============= -->
+	ag_kit_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><!-- ============= Table 'ag_survey_answer' ============= -->
 <rect class='table' x='675' y='683' width='150' height='120' rx='7' ry='7' />
 <path d='M 675.50 709.50 L 675.50 690.50 Q 675.50 683.50 682.50 683.50 L 817.50 683.50 Q 824.50 683.50 824.50 690.50 L 824.50 709.50 L675.50 709.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#ag_survey_answer'><text x='700' y='697' class='tableTitle'>ag_survey_answer</text><title>Table ag.ag_survey_answer</title></a>
@@ -1073,7 +1068,7 @@ Date barcode created on the system</title></a>
   <a xlink:href='#refunded'><text x='753' y='1207'>refunded</text><title>refunded varchar&#040;1&#041;</title></a>
 
 <!-- ============= Table 'survey_question' ============= -->
-<rect class='table' x='420' y='1523' width='150' height='105' rx='7' ry='7' />
+<rect class='table' x='420' y='1523' width='150' height='120' rx='7' ry='7' />
 <path d='M 420.50 1549.50 L 420.50 1530.50 Q 420.50 1523.50 427.50 1523.50 L 562.50 1523.50 Q 569.50 1523.50 569.50 1530.50 L 569.50 1549.50 L420.50 1549.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
 <a xlink:href='#survey_question'><text x='450' y='1537' class='tableTitle'>survey_question</text><title>Table ag.survey_question
 Stores the human survey questions</title></a>
@@ -1084,29 +1079,18 @@ The unique question ID</title></a>
 Referred by survey_answers_other ( survey_question_id ) 
 Referred by survey_question_response ( survey_question_id ) 
 Referred by survey_question_response_type ( survey_question_id ) 
-Referred by survey_question_triggers ( triggered_question -> survey_question_id ) 
-Referred by survey_question_retired ( survey_question_id ) 
-Referred by survey_question_retired ( survey_question_id ) 
-Referred by survey_question_retired ( survey_question_id ) </title></a>
-  <use id='nn' x='422' y='1572' xlink:href='#nn'/><a xlink:href='#question_shortname'><use id='unq' x='422' y='1571' xlink:href='#unq'/><title>Unique Index  ( question_shortname ) </title></a>
-<a xlink:href='#question_shortname'><text x='438' y='1582'>question_shortname</text><title>question_shortname varchar&#040;100&#041; not null
+Referred by survey_question_triggers ( triggered_question -> survey_question_id ) </title></a>
+  <a xlink:href='#retired'><text x='438' y='1582'>retired</text><title>retired bool default &#039;F&#039;
+Whether the question is shown or not</title></a>
+  <use id='nn' x='422' y='1587' xlink:href='#nn'/><a xlink:href='#question_shortname'><use id='unq' x='422' y='1586' xlink:href='#unq'/><title>Unique Index  ( question_shortname ) </title></a>
+<a xlink:href='#question_shortname'><text x='438' y='1597'>question_shortname</text><title>question_shortname varchar&#040;100&#041; not null
 A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown</title></a>
-  <a xlink:href='#american'><use id='unq' x='422' y='1586' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
-<a xlink:href='#american'><text x='438' y='1597'>american</text><title>american varchar&#040;2147483647&#041;
+  <a xlink:href='#american'><use id='unq' x='422' y='1601' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
+<a xlink:href='#american'><text x='438' y='1612'>american</text><title>american varchar&#040;2147483647&#041;
 The american english version of the question</title></a>
-  <a xlink:href='#british'><use id='unq' x='422' y='1601' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
-<a xlink:href='#british'><text x='438' y='1612'>british</text><title>british varchar&#040;2147483647&#041;
+  <a xlink:href='#british'><use id='unq' x='422' y='1616' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
+<a xlink:href='#british'><text x='438' y='1627'>british</text><title>british varchar&#040;2147483647&#041;
 The british english version of the question</title></a>
-
-<!-- ============= Table 'survey_question_retired' ============= -->
-<rect class='table' x='405' y='1658' width='150' height='75' rx='7' ry='7' />
-<path d='M 405.50 1684.50 L 405.50 1665.50 Q 405.50 1658.50 412.50 1658.50 L 547.50 1658.50 Q 554.50 1658.50 554.50 1665.50 L 554.50 1684.50 L405.50 1684.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
-<a xlink:href='#survey_question_retired'><text x='414' y='1672' class='tableTitle'>survey_question_retired</text><title>Table ag.survey_question_retired</title></a>
-  <use id='nn' x='407' y='1692' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='407' y='1691' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) </title></a>
-<a xlink:href='#survey_id'><text x='423' y='1702'>survey_id</text><title>survey_id bigint not null</title></a>
-  <use id='nn' x='407' y='1707' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='407' y='1706' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) Index  ( survey_question_id ) </title></a>
-<a xlink:href='#survey_question_id'><text x='423' y='1717'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
-<a xlink:href='#survey_question_id'><use id='fk' x='543' y='1706' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
 
 </g></svg>
 
@@ -3523,6 +3507,11 @@ The british english version of the question</title></a>
 		<td width='99%'> The unique question ID </td>
 	</tr>
 	<tr>
+		<td><a name='retired'>retired</a></td>
+		<td width='40%'> bool   DEFO 'F' </td>
+		<td width='99%'> Whether the question is shown or not </td>
+	</tr>
+	<tr>
 		<td><a name='question_shortname'>question&#095;shortname</a></td>
 		<td width='40%'> varchar&#040; 100 &#041;  NOT NULL  </td>
 		<td width='99%'> A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown </td>
@@ -3552,40 +3541,6 @@ The british english version of the question</title></a>
 	</tr>
 	<tr>		<td>idx&#095;survey&#095;question&#095;1 unique</td>
 		<td> ON question&#095;shortname</td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='survey_question_retired'>survey_question_retired</a></th></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='survey_id'>survey&#095;id</a></td>
-		<td width='40%'> bigint  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-	<tr>
-		<td><a name='survey_question_id'>survey&#095;question&#095;id</a></td>
-		<td width='40%'> bigint  NOT NULL  </td>
-		<td width='99%'>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>pk&#095;survey&#095;question&#095;retired primary key</td>
-		<td> ON survey&#095;id&#044; survey&#095;question&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;survey&#095;question&#095;retired </td>
-		<td> ON survey&#095;question&#095;id</td>
-		<td>  </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
-	<tr>
-		<td>fk_survey_question_retired</td>
-		<td > ( survey&#095;question&#095;id ) ref <a href='#survey&#095;question'>survey&#095;question</a> (survey&#095;question&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/amgut/db/ag.html
+++ b/amgut/db/ag.html
@@ -397,7 +397,12 @@
 	ag_kit_barcodes references barcode ( barcode )</title>
 </path>
 <text x='678' y='940' transform='rotate(0 678,940)' title='Foreign Key fk_ag_kit_barcodes_barcode
-	ag_kit_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><!-- ============= Table 'ag_survey_answer' ============= -->
+	ag_kit_barcodes references barcode ( barcode )' style='fill:#a1a0a0;'>barcode</text><path transform='translate(7,0)' marker-start='url(#foot)'     d='M 555 1710 L 577,1710 Q 585,1710 585,1702 L 585,1695' >
+	<title>Foreign Key fk_survey_question_retired
+	survey_question_retired references survey_question ( survey_question_id )</title>
+</path>
+<text x='562' y='1705' transform='rotate(0 562,1705)' title='Foreign Key fk_survey_question_retired
+	survey_question_retired references survey_question ( survey_question_id )' style='fill:#a1a0a0;'>survey_question_id</text><!-- ============= Table 'ag_survey_answer' ============= -->
 <rect class='table' x='675' y='683' width='150' height='120' rx='7' ry='7' />
 <path d='M 675.50 709.50 L 675.50 690.50 Q 675.50 683.50 682.50 683.50 L 817.50 683.50 Q 824.50 683.50 824.50 690.50 L 824.50 709.50 L675.50 709.50 ' style='fill:url(#tableHeaderGradient0); stroke:none;' />
 <a xlink:href='#ag_survey_answer'><text x='700' y='697' class='tableTitle'>ag_survey_answer</text><title>Table ag.ag_survey_answer</title></a>
@@ -646,29 +651,6 @@ Keeps track of the survey&#095;ids that correspond to surveys that were ported f
   <use id='nn' x='1427' y='942' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='1427' y='941' xlink:href='#pk'/><title>Primary Key  ( survey_id ) </title></a>
 <a xlink:href='#survey_id'><text x='1443' y='952'>survey_id</text><title>survey_id varchar&#040;2147483647&#041; not null</title></a>
 <a xlink:href='#survey_id'><use id='fk' x='1548' y='941' xlink:href='#fk'/><title>References ag_login_surveys ( survey_id ) </title></a>
-
-<!-- ============= Table 'survey_question' ============= -->
-<rect class='table' x='420' y='1523' width='150' height='105' rx='7' ry='7' />
-<path d='M 420.50 1549.50 L 420.50 1530.50 Q 420.50 1523.50 427.50 1523.50 L 562.50 1523.50 Q 569.50 1523.50 569.50 1530.50 L 569.50 1549.50 L420.50 1549.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
-<a xlink:href='#survey_question'><text x='450' y='1537' class='tableTitle'>survey_question</text><title>Table ag.survey_question
-Stores the human survey questions</title></a>
-  <use id='nn' x='422' y='1557' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='422' y='1556' xlink:href='#pk'/><title>Primary Key  ( survey_question_id ) </title></a>
-<a xlink:href='#survey_question_id'><text x='438' y='1567'>survey_question_id</text><title>survey_question_id bigint not null
-The unique question ID</title></a>
-<a xlink:href='#survey_question_id'><use id='ref' x='558' y='1556' xlink:href='#ref'/><title>Referred by group_questions ( survey_question_id ) 
-Referred by survey_answers_other ( survey_question_id ) 
-Referred by survey_question_response ( survey_question_id ) 
-Referred by survey_question_response_type ( survey_question_id ) 
-Referred by survey_question_triggers ( triggered_question -> survey_question_id ) </title></a>
-  <use id='nn' x='422' y='1572' xlink:href='#nn'/><a xlink:href='#question_shortname'><use id='unq' x='422' y='1571' xlink:href='#unq'/><title>Unique Index  ( question_shortname ) </title></a>
-<a xlink:href='#question_shortname'><text x='438' y='1582'>question_shortname</text><title>question_shortname varchar&#040;100&#041; not null
-A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown</title></a>
-  <a xlink:href='#american'><use id='unq' x='422' y='1586' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
-<a xlink:href='#american'><text x='438' y='1597'>american</text><title>american varchar&#040;2147483647&#041;
-The american english version of the question</title></a>
-  <a xlink:href='#british'><use id='unq' x='422' y='1601' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
-<a xlink:href='#british'><text x='438' y='1612'>british</text><title>british varchar&#040;2147483647&#041;
-The british english version of the question</title></a>
 
 <!-- ============= Table 'ag_login' ============= -->
 <rect class='table' x='705' y='398' width='120' height='225' rx='7' ry='7' />
@@ -1089,6 +1071,42 @@ Date barcode created on the system</title></a>
   <a xlink:href='#results_ready'><text x='753' y='1177'>results_ready</text><title>results_ready varchar&#040;1&#041;</title></a>
   <a xlink:href='#withdrawn'><text x='753' y='1192'>withdrawn</text><title>withdrawn varchar&#040;1&#041;</title></a>
   <a xlink:href='#refunded'><text x='753' y='1207'>refunded</text><title>refunded varchar&#040;1&#041;</title></a>
+
+<!-- ============= Table 'survey_question' ============= -->
+<rect class='table' x='420' y='1523' width='150' height='105' rx='7' ry='7' />
+<path d='M 420.50 1549.50 L 420.50 1530.50 Q 420.50 1523.50 427.50 1523.50 L 562.50 1523.50 Q 569.50 1523.50 569.50 1530.50 L 569.50 1549.50 L420.50 1549.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#survey_question'><text x='450' y='1537' class='tableTitle'>survey_question</text><title>Table ag.survey_question
+Stores the human survey questions</title></a>
+  <use id='nn' x='422' y='1557' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='422' y='1556' xlink:href='#pk'/><title>Primary Key  ( survey_question_id ) </title></a>
+<a xlink:href='#survey_question_id'><text x='438' y='1567'>survey_question_id</text><title>survey_question_id bigint not null
+The unique question ID</title></a>
+<a xlink:href='#survey_question_id'><use id='ref' x='558' y='1556' xlink:href='#ref'/><title>Referred by group_questions ( survey_question_id ) 
+Referred by survey_answers_other ( survey_question_id ) 
+Referred by survey_question_response ( survey_question_id ) 
+Referred by survey_question_response_type ( survey_question_id ) 
+Referred by survey_question_triggers ( triggered_question -> survey_question_id ) 
+Referred by survey_question_retired ( survey_question_id ) 
+Referred by survey_question_retired ( survey_question_id ) 
+Referred by survey_question_retired ( survey_question_id ) </title></a>
+  <use id='nn' x='422' y='1572' xlink:href='#nn'/><a xlink:href='#question_shortname'><use id='unq' x='422' y='1571' xlink:href='#unq'/><title>Unique Index  ( question_shortname ) </title></a>
+<a xlink:href='#question_shortname'><text x='438' y='1582'>question_shortname</text><title>question_shortname varchar&#040;100&#041; not null
+A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown</title></a>
+  <a xlink:href='#american'><use id='unq' x='422' y='1586' xlink:href='#unq'/><title>Unique Index  ( american ) </title></a>
+<a xlink:href='#american'><text x='438' y='1597'>american</text><title>american varchar&#040;2147483647&#041;
+The american english version of the question</title></a>
+  <a xlink:href='#british'><use id='unq' x='422' y='1601' xlink:href='#unq'/><title>Unique Index  ( british ) </title></a>
+<a xlink:href='#british'><text x='438' y='1612'>british</text><title>british varchar&#040;2147483647&#041;
+The british english version of the question</title></a>
+
+<!-- ============= Table 'survey_question_retired' ============= -->
+<rect class='table' x='405' y='1658' width='150' height='75' rx='7' ry='7' />
+<path d='M 405.50 1684.50 L 405.50 1665.50 Q 405.50 1658.50 412.50 1658.50 L 547.50 1658.50 Q 554.50 1658.50 554.50 1665.50 L 554.50 1684.50 L405.50 1684.50 ' style='fill:url(#tableHeaderGradient4); stroke:none;' />
+<a xlink:href='#survey_question_retired'><text x='414' y='1672' class='tableTitle'>survey_question_retired</text><title>Table ag.survey_question_retired</title></a>
+  <use id='nn' x='407' y='1692' xlink:href='#nn'/><a xlink:href='#survey_id'><use id='pk' x='407' y='1691' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) </title></a>
+<a xlink:href='#survey_id'><text x='423' y='1702'>survey_id</text><title>survey_id bigint not null</title></a>
+  <use id='nn' x='407' y='1707' xlink:href='#nn'/><a xlink:href='#survey_question_id'><use id='pk' x='407' y='1706' xlink:href='#pk'/><title>Primary Key  ( survey_id, survey_question_id ) Index  ( survey_question_id ) </title></a>
+<a xlink:href='#survey_question_id'><text x='423' y='1717'>survey_question_id</text><title>survey_question_id bigint not null</title></a>
+<a xlink:href='#survey_question_id'><use id='fk' x='543' y='1706' xlink:href='#fk'/><title>References survey_question ( survey_question_id ) </title></a>
 
 </g></svg>
 
@@ -1903,53 +1921,6 @@ Date barcode created on the system</title></a>
 	<tr>
 		<td>fk_promoted_survey_ids</td>
 		<td > ( survey&#095;id ) ref <a href='#ag&#095;login&#095;surveys'>ag&#095;login&#095;surveys</a> (survey&#095;id) </td>
-		<td>  </td>
-	</tr>
-</tbody>
-</table>
-
-<br/><br/>
-<table id='dbs' >
-<thead>
-<tr><th colspan='3'><a name='survey_question'>survey_question</a></th></tr>
-<tr><td colspan='3'>Stores the human survey questions </td></tr>
-</thead>
-<tbody>
-	<tr>
-		<td><a name='survey_question_id'>survey&#095;question&#095;id</a></td>
-		<td width='40%'> bigint  NOT NULL  </td>
-		<td width='99%'> The unique question ID </td>
-	</tr>
-	<tr>
-		<td><a name='question_shortname'>question&#095;shortname</a></td>
-		<td width='40%'> varchar&#040; 100 &#041;  NOT NULL  </td>
-		<td width='99%'> A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown </td>
-	</tr>
-	<tr>
-		<td><a name='american'>american</a></td>
-		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
-		<td width='99%'> The american english version of the question </td>
-	</tr>
-	<tr>
-		<td><a name='british'>british</a></td>
-		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
-		<td width='99%'> The british english version of the question </td>
-	</tr>
-<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
-	<tr>		<td>pk&#095;human&#095;survey&#095;question primary key</td>
-		<td> ON survey&#095;question&#095;id</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;survey&#095;question unique</td>
-		<td> ON american</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;survey&#095;question&#095;0 unique</td>
-		<td> ON british</td>
-		<td>  </td>
-	</tr>
-	<tr>		<td>idx&#095;survey&#095;question&#095;1 unique</td>
-		<td> ON question&#095;shortname</td>
 		<td>  </td>
 	</tr>
 </tbody>
@@ -3534,6 +3505,87 @@ Date barcode created on the system</title></a>
 	<tr>
 		<td>fk_ag_kit_barcodes_barcode</td>
 		<td > ( barcode ) ref <a href='#barcode'>barcode</a> (barcode) </td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='survey_question'>survey_question</a></th></tr>
+<tr><td colspan='3'>Stores the human survey questions </td></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='survey_question_id'>survey&#095;question&#095;id</a></td>
+		<td width='40%'> bigint  NOT NULL  </td>
+		<td width='99%'> The unique question ID </td>
+	</tr>
+	<tr>
+		<td><a name='question_shortname'>question&#095;shortname</a></td>
+		<td width='40%'> varchar&#040; 100 &#041;  NOT NULL  </td>
+		<td width='99%'> A QIIME mapping file&#045;compatible header that describes the question and can be used for metadata pulldown </td>
+	</tr>
+	<tr>
+		<td><a name='american'>american</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
+		<td width='99%'> The american english version of the question </td>
+	</tr>
+	<tr>
+		<td><a name='british'>british</a></td>
+		<td width='40%'> varchar&#040; 2147483647 &#041;   </td>
+		<td width='99%'> The british english version of the question </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>pk&#095;human&#095;survey&#095;question primary key</td>
+		<td> ON survey&#095;question&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;survey&#095;question unique</td>
+		<td> ON american</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;survey&#095;question&#095;0 unique</td>
+		<td> ON british</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;survey&#095;question&#095;1 unique</td>
+		<td> ON question&#095;shortname</td>
+		<td>  </td>
+	</tr>
+</tbody>
+</table>
+
+<br/><br/>
+<table id='dbs' >
+<thead>
+<tr><th colspan='3'><a name='survey_question_retired'>survey_question_retired</a></th></tr>
+</thead>
+<tbody>
+	<tr>
+		<td><a name='survey_id'>survey&#095;id</a></td>
+		<td width='40%'> bigint  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+	<tr>
+		<td><a name='survey_question_id'>survey&#095;question&#095;id</a></td>
+		<td width='40%'> bigint  NOT NULL  </td>
+		<td width='99%'>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Indexes</b></td></tr>
+	<tr>		<td>pk&#095;survey&#095;question&#095;retired primary key</td>
+		<td> ON survey&#095;id&#044; survey&#095;question&#095;id</td>
+		<td>  </td>
+	</tr>
+	<tr>		<td>idx&#095;survey&#095;question&#095;retired </td>
+		<td> ON survey&#095;question&#095;id</td>
+		<td>  </td>
+	</tr>
+<tr><td colspan='3' class='subpart'><b>Foreign Keys</b></td></tr>
+	<tr>
+		<td>fk_survey_question_retired</td>
+		<td > ( survey&#095;question&#095;id ) ref <a href='#survey&#095;question'>survey&#095;question</a> (survey&#095;question&#095;id) </td>
 		<td>  </td>
 	</tr>
 </tbody>

--- a/amgut/db/patches/0023.sql
+++ b/amgut/db/patches/0023.sql
@@ -1,0 +1,13 @@
+-- Sept 16, 2015
+-- Add way to retire questions
+--promote unmappable questions from old survey
+
+CREATE TABLE ag.survey_question_retired (
+	survey_id            bigint  NOT NULL,
+	survey_question_id   bigint  NOT NULL,
+	CONSTRAINT pk_survey_question_retired PRIMARY KEY ( survey_id, survey_question_id )
+ );
+CREATE INDEX idx_survey_question_retired_0 ON ag.survey_question_retired ( survey_question_id );
+-- No FK to survey_id so we can retire whole surveys
+ALTER TABLE ag.survey_question_retired ADD CONSTRAINT fk_survey_question_retired FOREIGN KEY ( survey_question_id ) REFERENCES ag.survey_question( survey_question_id );
+

--- a/amgut/db/patches/0023.sql
+++ b/amgut/db/patches/0023.sql
@@ -3,11 +3,50 @@
 --promote unmappable questions from old survey
 
 CREATE TABLE ag.survey_question_retired (
-	survey_id            bigint  NOT NULL,
-	survey_question_id   bigint  NOT NULL,
-	CONSTRAINT pk_survey_question_retired PRIMARY KEY ( survey_id, survey_question_id )
+    survey_id            bigint  NOT NULL,
+    survey_question_id   bigint  NOT NULL,
+    CONSTRAINT pk_survey_question_retired PRIMARY KEY ( survey_id, survey_question_id )
  );
 CREATE INDEX idx_survey_question_retired_0 ON ag.survey_question_retired ( survey_question_id );
 -- No FK to survey_id so we can retire whole surveys
 ALTER TABLE ag.survey_question_retired ADD CONSTRAINT fk_survey_question_retired FOREIGN KEY ( survey_question_id ) REFERENCES ag.survey_question( survey_question_id );
+GRANT INSERT, UPDATE, DELETE, SELECT ON ALL TABLES IN SCHEMA ag, public, barcodes TO "ag_wwwuser";
 
+-- Add plants question back as a retired question
+INSERT INTO survey_question (survey_question_id, question_shortname, american, british) VALUES (146, 'TYPES_OF_PLANTS', 'How many different species of plants did you consume during the last 7-day period?', 'How many different species of plants did you consume during the last 7-day period?');
+
+INSERT INTO survey_question_response_type (survey_question_id, survey_response_type) VALUES (146, 'SINGLE');
+
+INSERT INTO survey_response (american, british) VALUES ('Less than 5', 'Less than 5');
+INSERT INTO survey_response (american, british) VALUES ('6 to 10', '6 to 10');
+INSERT INTO survey_response (american, british) VALUES ('11 to 20', '11 to 20');
+INSERT INTO survey_response (american, british) VALUES ('21 to 30', '21 to 30');
+INSERT INTO survey_response (american, british) VALUES ('More than 30', 'More than 30');
+
+INSERT INTO survey_question_response (survey_question_id, response, display_index) VALUES (146, 'Unspecified', 0);
+INSERT INTO survey_question_response (survey_question_id, response, display_index) VALUES (146, 'Less than 5', 1);
+INSERT INTO survey_question_response (survey_question_id, response, display_index) VALUES (146, '6 to 10', 2);
+INSERT INTO survey_question_response (survey_question_id, response, display_index) VALUES (146, '11 to 20', 3);
+INSERT INTO survey_question_response (survey_question_id, response, display_index) VALUES (146, '21 to 30', 4);
+INSERT INTO survey_question_response (survey_question_id, response, display_index) VALUES (146, 'More than 30', 5);
+
+INSERT INTO survey_question_retired (survey_id, survey_question_id) VALUES (1, 146);
+
+-- Promote answers
+DO $do$
+DECLARE
+    top varchar;
+    survey varchar;
+    pid varchar;
+    login varchar;
+BEGIN
+    -- Make sure not in test database so there's actually something to promote
+    IF SELECT NOT EXISTS(SELECT 1
+                         FROM information_schema.tables 
+                         WHERE table_schema = 'ag' AND table_name = 'ag_human_survey')
+    THEN
+        RETURN;
+    END IF;
+
+    
+END $do$

--- a/amgut/db/patches/0023.sql
+++ b/amgut/db/patches/0023.sql
@@ -2,18 +2,10 @@
 -- Add way to retire questions
 --promote unmappable questions from old survey
 
-CREATE TABLE ag.survey_question_retired (
-    survey_id            bigint  NOT NULL,
-    survey_question_id   bigint  NOT NULL,
-    CONSTRAINT pk_survey_question_retired PRIMARY KEY ( survey_id, survey_question_id )
- );
-CREATE INDEX idx_survey_question_retired_0 ON ag.survey_question_retired ( survey_question_id );
--- No FK to survey_id so we can retire whole surveys
-ALTER TABLE ag.survey_question_retired ADD CONSTRAINT fk_survey_question_retired FOREIGN KEY ( survey_question_id ) REFERENCES ag.survey_question( survey_question_id );
-GRANT INSERT, UPDATE, DELETE, SELECT ON ALL TABLES IN SCHEMA ag, public, barcodes TO "ag_wwwuser";
-
+ALTER TABLE ag.survey_question ADD COLUMN retired boolean DEFAULT FALSE;
 -- Add plants question back as a retired question
-INSERT INTO survey_question (survey_question_id, question_shortname, american, british) VALUES (146, 'TYPES_OF_PLANTS', 'How many different species of plants did you consume during the last 7-day period?', 'How many different species of plants did you consume during the last 7-day period?');
+INSERT INTO survey_question (survey_question_id, question_shortname, american, british, retired) VALUES
+(146, 'TYPES_OF_PLANTS', 'How many different species of plants did you consume during the last 7-day period?', 'How many different species of plants did you consume during the last 7-day period?', TRUE);
 
 INSERT INTO survey_question_response_type (survey_question_id, survey_response_type) VALUES (146, 'SINGLE');
 
@@ -30,7 +22,7 @@ INSERT INTO survey_question_response (survey_question_id, response, display_inde
 INSERT INTO survey_question_response (survey_question_id, response, display_index) VALUES (146, '21 to 30', 4);
 INSERT INTO survey_question_response (survey_question_id, response, display_index) VALUES (146, 'More than 30', 5);
 
-INSERT INTO survey_question_retired (survey_id, survey_question_id) VALUES (1, 146);
+INSERT INTO group_questions (survey_group, survey_question_id, display_index) VALUES (-1, 146, 50);
 
 -- Promote answers
 DO $do$

--- a/amgut/lib/data_access/survey.py
+++ b/amgut/lib/data_access/survey.py
@@ -194,18 +194,22 @@ class Group(object):
     """
     _group_table = 'survey_group'
     _group_questions_table = 'group_questions'
+    _questions_table = 'survey_question'
 
     def __init__(self, ID):
         self.id = ID
         n = self.american_name
         qs = [Question.factory(x[0], n) for x in db_conn.execute_fetchall('''
-            select gq.survey_question_id
-            from {0} sg join {1} gq on sg.group_order = gq.survey_group
-            where sg.group_order = %s
-            order by gq.display_index
+            SELECT gq.survey_question_id
+            FROM {0} sg
+            JOIN {1} gq ON sg.group_order = gq.survey_group
+            LEFT JOIN {2} sq USING (survey_question_id)
+            WHERE sg.group_order = %s AND sq.retired = FALSE
+            ORDER BY gq.display_index
             '''.format(
                 self._group_table,
-                self._group_questions_table),
+                self._group_questions_table,
+                self._questions_table),
             [self.id])]
 
         self.id_to_eid = {q.id: q.interface_element_ids for q in qs}


### PR DESCRIPTION
This adds an easy way to retire questions. Retired questions will not show in the surveys, but will show in metadata pulldowns. 

This also moves over the old plants question as a retired question, allowing it to be pulled down.