### PR TITLE
add missing requirement 'requests'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(name='American Gut participant UI',
           'psycopg2',
           'pycrypto==2.6.1',
           'redis',
+          'requests',
           'tornado==3.2.2',
           'WTForms==2.0.1',
           'natsort'


### PR DESCRIPTION
Tried to run tests but they failed because the requirement 'requests', used from `amgut/handlers/sample_overview.py`, is not specified; I added it to `install_requires` in `setup.py`.