### PR TITLE
Use blank form on logging errors

### DIFF
--- a/amgut/handlers/add_sample.py
+++ b/amgut/handlers/add_sample.py
@@ -34,7 +34,8 @@ class AddSample(BaseHandler):
         if not form.validate():
             self.render('add_sample.html', skid=self.current_user,
                         participant_name=participant_name,
-                        form=form, page_type=self.page_type)
+                        form=self.build_form(), page_type=self.page_type,
+                        message='Invalid form submission, please try again')
             return
 
         barcode = form.barcode.data
@@ -65,7 +66,7 @@ class AddSample(BaseHandler):
         form = self.build_form()
         self.render('add_sample.html', skid=self.current_user,
                     participant_name=participant_name,
-                    form=form, page_type=self.page_type)
+                    form=form, page_type=self.page_type, message='')
 
     def build_form(self):
         kit_id = self.current_user

--- a/amgut/templates/add_sample.html
+++ b/amgut/templates/add_sample.html
@@ -25,7 +25,7 @@
 </script>
 
 <h2>{% raw tl['NEW_SAMPLE_TITLE'] %} {{ participant_name }}</h2>
-
+{% if message %} <h3>{{message}}</h3> {% end %}
 <form id="add_sample" name="add_sample" method="post" action="{% raw media_locale['SITEBASE'] %}/authed/{{page_type}}/">
     <input type="hidden" name="participant_name" value="{{ participant_name }}"/>
     <table width="100%">


### PR DESCRIPTION
This changes the sample logging page to render with a blank form when validation of the form fails.