### PR TITLE
Change barcode for testing

### DIFF
--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -413,7 +413,7 @@ class AGDataAccess(object):
                 INNER JOIN ag_kit ak USING (ag_kit_id)
                 WHERE ak.ag_login_id = %s and akb.barcode = %s);
 
-        UPDATE barcode SET status = '' WHERE barcode = %s;
+        UPDATE barcode SET status = NULL WHERE barcode = %s;
         """
         conn_handler = SQLConnectionHandler()
         conn_handler.execute(sql, [ag_login_id, barcode, barcode])

--- a/amgut/lib/data_access/test/test_ag_data_access.py
+++ b/amgut/lib/data_access/test/test_ag_data_access.py
@@ -223,7 +223,7 @@ class TestAGDataAccess(TestCase):
         self.ag_data.logParticipantSample(
             ag_login_id, barcode, None, 'animal_habitat',
             datetime.date(2015, 9, 26), datetime.time(15, 00), 'REMOVED', '')
-        obs = self.ag_data.getAGBarcodeDetails('000005626')
+        obs = self.ag_data.getAGBarcodeDetails(barcode)
         exp = {'status': None,
                'ag_kit_id': '5bfa9526-8dbb-492f-937c-bceb6b5a56fe',
                'ag_kit_barcode_id': '793dab39-d9bf-4a0f-8d67-f21796e3faae',

--- a/amgut/lib/data_access/test/test_ag_data_access.py
+++ b/amgut/lib/data_access/test/test_ag_data_access.py
@@ -190,33 +190,32 @@ class TestAGDataAccess(TestCase):
 
     def test_logParticipantSample(self):
         # regular sample
-        ag_login_id = 'd8592c74-9694-2135-e040-8a80115d6401'
-        barcode = '000005626'
+        ag_login_id = '7732aafe-c4e1-4ae4-8337-6f22704c1064'
+        barcode = '000027376'
 
         self.ag_data.logParticipantSample(
             ag_login_id, barcode, 'Stool', None, datetime.date(2015, 9, 27),
             datetime.time(15, 54), 'REMOVED-0', '')
-        obs = self.ag_data.getAGBarcodeDetails('000005626')
-        exp = {
-            'status': '',
-            'ag_kit_id': 'db447092-6209-54d8-e040-8a80115d3637',
-            'ag_kit_barcode_id': 'db447092-620c-54d8-e040-8a80115d3637',
-            'barcode': '000005626',
-            'environment_sampled': None,
-            'site_sampled': 'Stool',
-            'name': 'REMOVED',
-            'sample_date': datetime.date(2015, 9, 27),
-            'sample_time': datetime.time(15, 54),
-            'notes': '', 'overloaded': None,
-            'withdrawn': None,
-            'email': 'REMOVED',
-            'other': None,
-            'moldy': None,
-            'participant_name': 'REMOVED-0',
-            'refunded': None,
-            'date_of_last_email': None,
-            'other_text': 'REMOVED'
-        }
+        obs = self.ag_data.getAGBarcodeDetails(barcode)
+        exp = {'status': None,
+               'ag_kit_id': '5bfa9526-8dbb-492f-937c-bceb6b5a56fe',
+               'ag_kit_barcode_id': '793dab39-d9bf-4a0f-8d67-f21796e3faae',
+               'barcode': '000027376',
+               'site_sampled': 'Stool',
+               'environment_sampled': None,
+               'name': 'REMOVED',
+               'sample_date': datetime.date(2015, 9, 27),
+               'sample_time': datetime.time(15, 54),
+               'notes': '', 'overloaded': None,
+               'withdrawn': None,
+               'email': 'REMOVED',
+               'other': None,
+               'moldy': None,
+               'participant_name': 'REMOVED-0',
+               'refunded': None,
+               'date_of_last_email': None,
+               'other_text': 'REMOVED'
+               }
         self.assertEqual(obs, exp)
         self.ag_data.deleteSample(barcode, ag_login_id)
 
@@ -225,26 +224,25 @@ class TestAGDataAccess(TestCase):
             ag_login_id, barcode, None, 'animal_habitat',
             datetime.date(2015, 9, 26), datetime.time(15, 00), 'REMOVED', '')
         obs = self.ag_data.getAGBarcodeDetails('000005626')
-        exp = {
-            'status': '',
-            'ag_kit_id': 'db447092-6209-54d8-e040-8a80115d3637',
-            'ag_kit_barcode_id': 'db447092-620c-54d8-e040-8a80115d3637',
-            'barcode': '000005626',
-            'environment_sampled': 'animal_habitat',
-            'site_sampled': None,
-            'name': 'REMOVED',
-            'sample_date': datetime.date(2015, 9, 26),
-            'sample_time': datetime.time(15, 00),
-            'notes': '', 'overloaded': None,
-            'withdrawn': None,
-            'email': 'REMOVED',
-            'other': None,
-            'moldy': None,
-            'participant_name': 'REMOVED',
-            'refunded': None,
-            'date_of_last_email': None,
-            'other_text': 'REMOVED'
-        }
+        exp = {'status': None,
+               'ag_kit_id': '5bfa9526-8dbb-492f-937c-bceb6b5a56fe',
+               'ag_kit_barcode_id': '793dab39-d9bf-4a0f-8d67-f21796e3faae',
+               'barcode': '000027376',
+               'site_sampled': None,
+               'environment_sampled': 'animal_habitat',
+               'name': 'REMOVED',
+               'sample_date': datetime.date(2015, 9, 26),
+               'sample_time': datetime.time(15, 00),
+               'notes': '', 'overloaded': None,
+               'withdrawn': None,
+               'email': 'REMOVED',
+               'other': None,
+               'moldy': None,
+               'participant_name': 'REMOVED',
+               'refunded': None,
+               'date_of_last_email': None,
+               'other_text': 'REMOVED'
+               }
         self.assertEqual(obs, exp)
 
         self.ag_data.deleteSample(barcode, ag_login_id)

--- a/amgut/lib/data_access/test/test_ag_data_access.py
+++ b/amgut/lib/data_access/test/test_ag_data_access.py
@@ -216,8 +216,8 @@ class TestAGDataAccess(TestCase):
                'date_of_last_email': None,
                'other_text': 'REMOVED'
                }
-        self.assertEqual(obs, exp)
         self.ag_data.deleteSample(barcode, ag_login_id)
+        self.assertEqual(obs, exp)
 
         # env sample
         self.ag_data.logParticipantSample(
@@ -243,9 +243,8 @@ class TestAGDataAccess(TestCase):
                'date_of_last_email': None,
                'other_text': 'REMOVED'
                }
-        self.assertEqual(obs, exp)
-
         self.ag_data.deleteSample(barcode, ag_login_id)
+        self.assertEqual(obs, exp)
 
     def test_deleteSample(self):
         raise NotImplementedError()


### PR DESCRIPTION
This makes logParticipantSample test work. Previously it was using a barcode used in another test, so the interaction between the two was causing stochastic failures depending on the order the tests were run.