### PR TITLE
Add continue/start option for vioscreen to participant overview

### DIFF
--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -249,7 +249,10 @@ _PARTICIPANT_OVERVIEW = {
     'COMPLETED_CONSENT': 'Completed consent',
     'COMPLETED_SURVEY': 'Completed survey',
     'SAMPLES_ASSIGNED': 'Samples assigned',
-    'OVERVIEW_FOR_PARTICPANT': 'Overview for participant'
+    'OVERVIEW_FOR_PARTICPANT': 'Overview for participant',
+    'VIOSCREEN_CONTINUE': '<a href="%s">Continue your Food Frequency Questionnaire</a>',
+    'VIOSCREEN_COMPLETE': 'Food Frequency Questionnaire completed',
+    'VIOSCREEN_START': '<a href="%s">Start the Food Frequency Questionnaire</a>'
 }
 
 _ADD_SAMPLE_OVERVIEW = {

--- a/amgut/lib/locale_data/british_gut.py
+++ b/amgut/lib/locale_data/british_gut.py
@@ -501,7 +501,9 @@ _PARTICIPANT_OVERVIEW = {
     'COMPLETED_CONSENT': "Completed consent",
     'COMPLETED_SURVEY': "Completed survey",
     'OVERVIEW_FOR_PARTICPANT': "Overview for participant",
-    'SAMPLES_ASSIGNED': "Samples assigned        ",
+    'SAMPLES_ASSIGNED': "Samples assigned",
+    'VIOSCREEN_CONTINUE': 'Continue Vioscreen survey',
+    'VIOSCREEN_COMPLETE': 'Vioscreen survey completed'
 }
 
 # helper tuples for the survey questions

--- a/amgut/lib/locale_data/british_gut.py
+++ b/amgut/lib/locale_data/british_gut.py
@@ -502,8 +502,9 @@ _PARTICIPANT_OVERVIEW = {
     'COMPLETED_SURVEY': "Completed survey",
     'OVERVIEW_FOR_PARTICPANT': "Overview for participant",
     'SAMPLES_ASSIGNED': "Samples assigned",
-    'VIOSCREEN_CONTINUE': 'Continue Vioscreen survey',
-    'VIOSCREEN_COMPLETE': 'Vioscreen survey completed'
+    'VIOSCREEN_CONTINUE': '<a href="%s">Continue your Food Frequency Questionnaire</a>',
+    'VIOSCREEN_COMPLETE': 'Food Frequency Questionnaire completed',
+    'VIOSCREEN_START': '<a href="%s">Start the Food Frequency Questionnaire</a>'
 }
 
 # helper tuples for the survey questions

--- a/amgut/templates/participant_overview.html
+++ b/amgut/templates/participant_overview.html
@@ -30,12 +30,13 @@
                         <input type="hidden" name="page_number" value=-1>
                         <input type="button" name="submit_button" id="submit_button" value="edit" onclick="submitEdit()">
                     </form>
+                    {% raw vioscreen_text %}
 {% elif participant_type == 'animal' %}
                     <form id="edit_survey" name="edit_survey" method="get" action="{% raw media_locale['SITEBASE'] %}/authed/add_animal/">
                         <input type="hidden" name="survey" value={{ survey_id}}>
                         <input type="button" name="submit_button" id="submit_button" value="edit" onclick="submitEdit()">
                     </form>
-
+                    {%raw vioscreen_text %}
 {% end %}
                 </td>
                 <td><img src="{% raw media_locale['SITEBASE'] %}/static/img/icon-green-checkmark.png"/></td>

--- a/amgut/templates/participant_overview.html
+++ b/amgut/templates/participant_overview.html
@@ -36,7 +36,6 @@
                         <input type="hidden" name="survey" value={{ survey_id}}>
                         <input type="button" name="submit_button" id="submit_button" value="edit" onclick="submitEdit()">
                     </form>
-                    {%raw vioscreen_text %}
 {% end %}
                 </td>
                 <td><img src="{% raw media_locale['SITEBASE'] %}/static/img/icon-green-checkmark.png"/></td>


### PR DESCRIPTION
This adds a simple link to start/continue the vioscreen survey under the survey edit button. It also lets you know if the survey is complete. Example below:

<img width="636" alt="screen shot 2015-10-26 at 09 16 47" src="https://cloud.githubusercontent.com/assets/3079066/10734826/65bef53e-7bc2-11e5-95bf-fc9706ad9bed.png">
