### PR TITLE
Add explicit delete of registered handout barcodes

### DIFF
--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -276,7 +276,7 @@ class AGDataAccess(object):
                     DELETE FROM ag_handout_kits WHERE kit_id = %s;
                 END $do$;
                 """.format(ag_login_id, printresults)
-            TRN.add(sql, [supplied_kit_id] * 3)
+            TRN.add(sql, [supplied_kit_id] * 4)
             try:
                 TRN.execute()
             except psycopg2.IntegrityError:

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -272,6 +272,7 @@ class AGDataAccess(object):
                             (ag_kit_id, barcode, sample_barcode_file)
                             VALUES (k_id, bc, bc || '.jpg');
                     END LOOP;
+                    DELETE FROM ag_handout_barcodes WHERE kit_id = %s;
                     DELETE FROM ag_handout_kits WHERE kit_id = %s;
                 END $do$;
                 """.format(ag_login_id, printresults)


### PR DESCRIPTION
Still getting an issue of barcodes not being deleted when registered using the cascade. This makes it explicit.