### PR TITLE
Fix typos for shortnames

### DIFF
--- a/amgut/db/patches/0030.sql
+++ b/amgut/db/patches/0030.sql
@@ -1,4 +1,4 @@
 --November 7, 2015
 --Fix typos in column shortnames
 UPDATE ag.survey_question SET question_shortname = 'FROZEN_DESSERT_FREQUENCY' WHERE survey_question_id = 66;
-UPDATE ag.survey_question set question_shortname = 'OTHER_CONDITIONS_LIST' WHERE survey_question_id = 106;
+UPDATE ag.survey_question SET question_shortname = 'OTHER_CONDITIONS_LIST' WHERE survey_question_id = 106;

--- a/amgut/db/patches/0030.sql
+++ b/amgut/db/patches/0030.sql
@@ -1,0 +1,4 @@
+--November 7, 2015
+--Fix typos in column shortnames
+UPDATE ag.survey_question SET question_shortname = 'FROZEN_DESSERT_FREQUENCY' WHERE survey_question_id = 66;
+UPDATE ag.survey_question set question_shortname = 'OTHER_CONDITIONS_LIST' WHERE survey_question_id = 106;


### PR DESCRIPTION
Part of labadmin pulldown fix [#31](https://github.com/biocore/labadmin/issues/31)