### PR TITLE
Small fix for Open Humans

### DIFF
--- a/amgut/static/js/open_humans.js
+++ b/amgut/static/js/open_humans.js
@@ -9,7 +9,7 @@ $(function () {
 
   $('#connect-open-humans').click(function () {
     var participants = $('.participant:checked').map(function () {
-      return $(this).attr('name');
+      return $(this).data('survey-id');
     }).get();
 
     Cookies.set('link-survey-id', btoa(JSON.stringify(participants)));

--- a/amgut/templates/open-humans.html
+++ b/amgut/templates/open-humans.html
@@ -65,7 +65,8 @@
         <p>
         {% for participant, survey_id in survey_ids.items() %}
           <label>
-            <input type="checkbox" name="{{ participant }}" class="participant">
+            <input type="checkbox" name="{{ participant }}"
+              data-survey-id="{{ survey_id }}" class="participant">
 
             {{ participant }}
           </label>


### PR DESCRIPTION
Not sure what changed (I looked at recent commits and didn't see anything that would impact this) but @madprime noticed that people linked American Gut to Open Humans were having their participant ID saved and not their survey ID. This did work at one point, though maybe my code relied on something from the database that it shouldn't have. This commit makes it explicit that it's the `survey_id` we're sending.

cc @EmbrietteH