### PR TITLE
Also null out survey id when removing barcode

### DIFF
--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -386,7 +386,8 @@ class AGDataAccess(object):
             sql = """UPDATE ag_kit_barcodes
                      SET participant_name = NULL, site_sampled = NULL,
                          sample_time = NULL, sample_date = NULL,
-                         environment_sampled = NULL, notes = ''
+                         environment_sampled = NULL, notes = NULL,
+                         survey_id = NULL
                     WHERE barcode IN (
                         SELECT  akb.barcode
                         FROM ag_kit_barcodes akb


### PR DESCRIPTION
This fixes an oversight when removing the barcode where the survey ID was left in despite the barcode being un-associated with anything. 