### PR TITLE
Auto-withdraw or release barcodes

### DIFF
--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -413,7 +413,7 @@ class AGDataAccess(object):
         -----
         Strictly speaking the ag_login_id isn't needed but it makes it really
         hard to hack the function when you would need to know someone else's
-        login id (a GUID) to delete something maliciously,
+        login id (a GUID) to delete something maliciously.
 
         If the barcode has never been scanned, assume a mis-log and wipe it so
         barcode can be logged again. If barcode has been scanned, that means we

--- a/amgut/lib/data_access/sql_connection.py
+++ b/amgut/lib/data_access/sql_connection.py
@@ -53,6 +53,7 @@ class Transaction(object):
         self._connection = None
         self._post_commit_funcs = []
         self._post_rollback_funcs = []
+        self.auto_rollback = False
 
     def _open_connection(self):
         # If the connection already exists and is not closed, don't do anything
@@ -125,10 +126,12 @@ class Transaction(object):
         return self
 
     def _clean_up(self, exc_type):
-        if exc_type is not None:
+        if exc_type is not None or self.auto_rollback:
             # An exception occurred during the execution of the transaction
+            # or we have set the current transaction block to auto-rollback
             # Make sure that we leave the DB w/o any modification
             self.rollback()
+            self.auto_rollback = False
         elif self._queries:
             # There are still queries to be executed, execute them
             # It is safe to use the execute method here, as internally is

--- a/amgut/lib/data_access/sql_connection.py
+++ b/amgut/lib/data_access/sql_connection.py
@@ -53,7 +53,6 @@ class Transaction(object):
         self._connection = None
         self._post_commit_funcs = []
         self._post_rollback_funcs = []
-        self.auto_rollback = False
 
     def _open_connection(self):
         # If the connection already exists and is not closed, don't do anything
@@ -126,12 +125,10 @@ class Transaction(object):
         return self
 
     def _clean_up(self, exc_type):
-        if exc_type is not None or self.auto_rollback:
+        if exc_type is not None:
             # An exception occurred during the execution of the transaction
-            # or we have set the current transaction block to auto-rollback
             # Make sure that we leave the DB w/o any modification
             self.rollback()
-            self.auto_rollback = False
         elif self._queries:
             # There are still queries to be executed, execute them
             # It is safe to use the execute method here, as internally is

--- a/amgut/lib/data_access/test/test_ag_data_access.py
+++ b/amgut/lib/data_access/test/test_ag_data_access.py
@@ -5,6 +5,7 @@ from string import ascii_letters
 from uuid import UUID
 
 from amgut.lib.data_access.ag_data_access import AGDataAccess
+from amgut.lib.data_access.sql_connection import TRN
 
 
 class TestAGDataAccess(TestCase):
@@ -163,8 +164,21 @@ class TestAGDataAccess(TestCase):
         obs = self.ag_data.getAGKitDetails(kit)
         self.assertEqual(obs['supplied_kit_id'], kit)
 
-    def test_getConsent(self):
+    def test_deleteAGParticipantSurvey(self):
+        with TRN:
+            TRN.auto_rollback = True
+            self.ag_data.deleteAGParticipantSurvey(
+                '000fc4cd-8fa4-db8b-e050-8a800c5d02b5', 'REMOVED-0')
+            with self.assertRaises(ValueError):
+                self.ag_data.getConsent('8b2b45bb3390b585')
 
+            res = self.ag_data.get_withdrawn()
+            today = datetime.datetime.now().date()
+            exp = [['000fc4cd-8fa4-db8b-e050-8a800c5d02b5', 'REMOVED-0',
+                    'REMOVED', today]]
+            self.assertItemsEqual(res, exp)
+
+    def test_getConsent(self):
         res = self.ag_data.getConsent("8b2b45bb3390b585")
         exp = {'date_signed': None,
                'assent_obtainer': None,

--- a/amgut/lib/data_access/test/test_ag_data_access.py
+++ b/amgut/lib/data_access/test/test_ag_data_access.py
@@ -5,7 +5,7 @@ from string import ascii_letters
 from uuid import UUID
 
 from amgut.lib.data_access.ag_data_access import AGDataAccess
-from amgut.lib.data_access.sql_connection import TRN
+from amgut.lib.util import rollback
 
 
 class TestAGDataAccess(TestCase):
@@ -164,19 +164,18 @@ class TestAGDataAccess(TestCase):
         obs = self.ag_data.getAGKitDetails(kit)
         self.assertEqual(obs['supplied_kit_id'], kit)
 
+    @rollback
     def test_deleteAGParticipantSurvey(self):
-        with TRN:
-            TRN.auto_rollback = True
-            self.ag_data.deleteAGParticipantSurvey(
-                '000fc4cd-8fa4-db8b-e050-8a800c5d02b5', 'REMOVED-0')
-            with self.assertRaises(ValueError):
-                self.ag_data.getConsent('8b2b45bb3390b585')
+        self.ag_data.deleteAGParticipantSurvey(
+            '000fc4cd-8fa4-db8b-e050-8a800c5d02b5', 'REMOVED-0')
+        with self.assertRaises(ValueError):
+            self.ag_data.getConsent('8b2b45bb3390b585')
 
-            res = self.ag_data.get_withdrawn()
-            today = datetime.datetime.now().date()
-            exp = [['000fc4cd-8fa4-db8b-e050-8a800c5d02b5', 'REMOVED-0',
-                    'REMOVED', today]]
-            self.assertItemsEqual(res, exp)
+        res = self.ag_data.get_withdrawn()
+        today = datetime.datetime.now().date()
+        exp = [['000fc4cd-8fa4-db8b-e050-8a800c5d02b5', 'REMOVED-0',
+                'REMOVED', today]]
+        self.assertItemsEqual(res, exp)
 
     def test_getConsent(self):
         res = self.ag_data.getConsent("8b2b45bb3390b585")

--- a/amgut/lib/test/test_util.py
+++ b/amgut/lib/test/test_util.py
@@ -1,9 +1,16 @@
 from unittest import TestCase, main
 from amgut.lib.util import (survey_fermented, survey_surf, survey_vioscreen,
-                            survey_asd)
+                            survey_asd, rollback)
+from amgut.lib.data_access.ag_data_access import AGDataAccess
 
 
 class TestUtil(TestCase):
+    def setUp(self):
+        self.ag_data = AGDataAccess()
+
+    def tearDown(self):
+        del self.ag_data
+
     def test_survey_fermented(self):
         obs = survey_fermented('survey_id', {'participant_name': 'test'})
         exp = ('<h3 style="text-align: center"><a href="/authed/'
@@ -51,6 +58,20 @@ class TestUtil(TestCase):
                       'by the Mayo Clinic.', obs)
         self.assertIn('<h3 style="text-align: center"><a href="'
                       'https://vioscreen.com/remotelogin.aspx?Key=', obs)
+
+    def test_rolback(self):
+        kit = 'tst_QCSKc'
+
+        @rollback
+        def tf(kit):
+            self.ag_data.verifyKit(kit)
+
+        obs = self.ag_data.getAGKitDetails(kit)
+        self.assertEqual(obs['kit_verified'], 'n')
+
+        tf(kit)
+        obs = self.ag_data.getAGKitDetails(kit)
+        self.assertEqual(obs['kit_verified'], 'n')
 
 
 if __name__ == '__main__':

--- a/amgut/lib/util.py
+++ b/amgut/lib/util.py
@@ -16,6 +16,7 @@ from tornado.escape import url_escape
 from wtforms import Form
 
 from amgut import media_locale, text_locale
+from amgut.lib.data_access.sql_connection import TRN
 from amgut.connections import redis
 from amgut.lib.vioscreen import encrypt_key
 
@@ -144,6 +145,14 @@ def survey_asd(survey_id):
 
 
 external_surveys = (survey_vioscreen,)  # survey_asd)
+
+
+def rollback(f):
+    """Decorator for test functions to rollback on complete."""
+    def inner(*args, **kwargs):
+        with TRN:
+            f(*args, **kwargs)
+            TRN.rollback()
 
 
 def basejoin(base, url):

--- a/amgut/lib/util.py
+++ b/amgut/lib/util.py
@@ -168,8 +168,10 @@ def rollback(f):
     """Decorator for test functions to rollback on complete."""
     def inner(*args, **kwargs):
         with TRN:
-            f(*args, **kwargs)
+            x = f(*args, **kwargs)
             TRN.rollback()
+            return x
+    return inner
 
 
 def basejoin(base, url):


### PR DESCRIPTION
This updates the code for someone revoking consent to have the barcode either returned to be re-associated if the person still has it, or set to withdrawn if the sample has already been sent in. It also adds logic to log when a participant has withdrawn consent.