### PR TITLE
Centralize participant_name info

### DIFF
--- a/amgut/db/patches/0038.sql
+++ b/amgut/db/patches/0038.sql
@@ -1,0 +1,3 @@
+-- June 21, 2016
+-- Remove legacy participant_name column and centralize on proper one.
+ALTER TABLE ag.ag_kit_barcodes DROP COLUMN participant_name;

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -177,7 +177,7 @@ class AGDataAccess(object):
         ValueError
             Barcode not found in AG information tables
         """
-        sql = """SELECT  email,
+        sql = """SELECT  DISTINCT email,
                     cast(ag_kit_barcode_id as varchar(100)),
                     cast(ag_kit_id as varchar(100)),
                     barcode, site_sampled, environment_sampled, sample_date,
@@ -186,8 +186,9 @@ class AGDataAccess(object):
                     name, status
                   FROM ag_kit_barcodes
                   INNER JOIN ag_kit USING (ag_kit_id)
+                  FULL OUTER JOIN ag_login_surveys
+                    USING (survey_id, ag_login_id)
                   INNER JOIN ag_login USING (ag_login_id)
-                  INNER JOIN ag_login_surveys USING (survey_id, ag_login_id)
                   INNER JOIN barcode USING (barcode)
                   WHERE barcode = %s"""
 

--- a/amgut/lib/data_access/ag_data_access.py
+++ b/amgut/lib/data_access/ag_data_access.py
@@ -187,6 +187,7 @@ class AGDataAccess(object):
                   FROM ag_kit_barcodes
                   INNER JOIN ag_kit USING (ag_kit_id)
                   INNER JOIN ag_login USING (ag_login_id)
+                  INNER JOIN ag_login_surveys USING (survey_id, ag_login_id)
                   INNER JOIN barcode USING (barcode)
                   WHERE barcode = %s"""
 
@@ -310,10 +311,9 @@ class AGDataAccess(object):
             TRN.add(sql, [survey_id])
 
             # Reset survey attached to barcode(s)
-            sql = """UPDATE ag_kit_barcodes
-                     SET survey_id = NULL
-                     WHERE survey_id = %s"""
-            TRN.add(sql, [survey_id])
+            for info in self.getParticipantSamples(ag_login_id,
+                                                   participant_name):
+                self.deleteSample(info['barcode'])
 
             sql = "DELETE FROM promoted_survey_ids WHERE survey_id = %s"
             TRN.add(sql, [survey_id])
@@ -393,10 +393,10 @@ class AGDataAccess(object):
             sql = """UPDATE ag_kit_barcodes
                      SET site_sampled = %s, environment_sampled = %s,
                          sample_date = %s, sample_time = %s,
-                         participant_name = %s, notes = %s, survey_id = %s
+                         notes = %s, survey_id = %s
                      WHERE barcode = %s"""
             TRN.add(sql, [sample_site, environment_sampled, sample_date,
-                          sample_time, participant_name, notes, survey_id,
+                          sample_time, notes, survey_id,
                           barcode])
 
     def deleteSample(self, barcode, ag_login_id):
@@ -427,7 +427,7 @@ class AGDataAccess(object):
 
             if not received:
                 # Not recieved, so we release the barcode back to be relogged
-                set_text = """participant_name = NULL, site_sampled = NULL,
+                set_text = """site_sampled = NULL,
                              sample_time = NULL, sample_date = NULL,
                              environment_sampled = NULL, notes = NULL,
                              survey_id = NULL"""
@@ -494,7 +494,7 @@ class AGDataAccess(object):
             return status[0][0]
 
     def getAnimalParticipants(self, ag_login_id):
-        sql = """SELECT participant_name from ag.ag_login_surveys
+        sql = """SELECT DISTINCT participant_name from ag.ag_login_surveys
                  JOIN ag.survey_answers USING (survey_id)
                  JOIN ag.group_questions gq USING (survey_question_id)
                  JOIN ag.surveys ags USING (survey_group)
@@ -509,6 +509,7 @@ class AGDataAccess(object):
                  FROM ag_kit_barcodes akb
                  INNER JOIN barcode USING (barcode)
                  INNER JOIN ag_kit ak USING (ag_kit_id)
+                 INNER JOIN ag_login_surveys USING (survey_id, ag_login_id)
                  WHERE (site_sampled IS NOT NULL AND site_sampled::text <> '')
                  AND ag_login_id = %s AND participant_name = %s"""
         with TRN:
@@ -798,6 +799,7 @@ class AGDataAccess(object):
             sql = """SELECT barcode, participant_name
                      FROM ag_kit_barcodes
                      INNER JOIN ag_kit USING (ag_kit_id)
+                     INNER JOIN ag_login_surveys USING (survey_id, ag_login_id)
                      WHERE ag_login_id = %s AND results_ready = 'Y'"""
 
             TRN.add(sql, [ag_login_id])

--- a/amgut/lib/data_access/test/test_ag_data_access.py
+++ b/amgut/lib/data_access/test/test_ag_data_access.py
@@ -91,7 +91,7 @@ class TestAGDataAccess(TestCase):
             'status': 'Received',
             'ag_kit_id': 'd8592c74-7e35-2135-e040-8a80115d6401',
             'name': 'REMOVED',
-            'participant_name': 'REMOVED',
+            'participant_name': 'REMOVED-0',
             'email': 'REMOVED',
             'site_sampled': 'Stool',
             'environment_sampled': None,
@@ -254,7 +254,7 @@ class TestAGDataAccess(TestCase):
                'email': 'REMOVED',
                'other': None,
                'moldy': None,
-               'participant_name': 'REMOVED',
+               'participant_name': None,
                'refunded': None,
                'date_of_last_email': None,
                'other_text': 'REMOVED'
@@ -290,10 +290,7 @@ class TestAGDataAccess(TestCase):
     def test_getAnimalParticipants(self):
         i = "ed5ab96f-fe3b-ead5-e040-8a80115d1c4b"
         res = self.ag_data.getAnimalParticipants(i)
-        exp = ['REMOVED-0', 'REMOVED-0', 'REMOVED-0', 'REMOVED-0',
-               'REMOVED-0', 'REMOVED-0', 'REMOVED-0', 'REMOVED-0',
-               'REMOVED-0', 'REMOVED-0', 'REMOVED-0', 'REMOVED-0',
-               'REMOVED-0', 'REMOVED-0']
+        exp = ['REMOVED-0']
         self.assertItemsEqual(res, exp)
 
     def test_getAnimalParticipantsNotPresent(self):
@@ -303,7 +300,7 @@ class TestAGDataAccess(TestCase):
 
     def test_getParticipantSamples(self):
         i = "d6b0f287-b9d9-40d4-82fd-a8fd3db6c476"
-        res = self.ag_data.getParticipantSamples(i, "REMOVED")
+        res = self.ag_data.getParticipantSamples(i, "REMOVED-0")
         exp = [{'status': None,
                 'sample_time': datetime.time(11, 55),
                 'notes': 'REMOVED',
@@ -313,7 +310,7 @@ class TestAGDataAccess(TestCase):
         self.assertEqual(res, exp)
 
         i = "d8592c74-9694-2135-e040-8a80115d6401"
-        res = self.ag_data.getParticipantSamples(i, "REMOVED")
+        res = self.ag_data.getParticipantSamples(i, "REMOVED-0")
         exp = [{'status': 'Received',
                 'sample_time': datetime.time(7, 40),
                 'notes': 'REMOVED',
@@ -649,23 +646,23 @@ class TestAGDataAccess(TestCase):
 
     def test_get_barcode_results(self):
         obs = self.ag_data.get_barcode_results('tst_yCzro')
-        exp = [{'barcode': '000016704', 'participant_name': 'REMOVED'},
-               {'barcode': '000016705', 'participant_name': 'REMOVED'},
-               {'barcode': '000016706', 'participant_name': 'REMOVED'},
-               {'barcode': '000016707', 'participant_name': 'REMOVED'},
-               {'barcode': '000016708', 'participant_name': 'REMOVED'},
-               {'barcode': '000016709', 'participant_name': 'REMOVED'},
-               {'barcode': '000016710', 'participant_name': 'REMOVED'},
-               {'barcode': '000016711', 'participant_name': 'REMOVED'},
-               {'barcode': '000016712', 'participant_name': 'REMOVED'},
-               {'barcode': '000016713', 'participant_name': 'REMOVED'},
-               {'barcode': '000004213', 'participant_name': 'REMOVED'},
-               {'barcode': '000004214', 'participant_name': 'REMOVED'},
-               {'barcode': '000004215', 'participant_name': 'REMOVED'},
-               {'barcode': '000004216', 'participant_name': 'REMOVED'},
-               {'barcode': '000004218', 'participant_name': 'REMOVED'},
-               {'barcode': '000004219', 'participant_name': 'REMOVED'}]
-        self.assertEqual(obs, exp)
+        exp = [{'barcode': '000016704', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016705', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016706', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016707', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016708', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016709', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016710', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016711', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016712', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000016713', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000004213', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000004214', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000004215', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000004216', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000004218', 'participant_name': 'REMOVED-0'},
+               {'barcode': '000004219', 'participant_name': 'REMOVED-0'}]
+        self.assertItemsEqual(obs, exp)
 
     def test_get_barcode_results_non_existant_id(self):
         with self.assertRaises(ValueError):

--- a/amgut/test/test_add_sample.py
+++ b/amgut/test/test_add_sample.py
@@ -181,7 +181,7 @@ class TestAddSample(TestHandlerBase):
             'email': 'REMOVED',
             'other': None,
             'moldy': None,
-            'participant_name': 'environmental',
+            'participant_name': None,
             'refunded': None,
             'date_of_last_email': None,
             'other_text': 'REMOVED'


### PR DESCRIPTION
This removes the legacy participant_name column in ag_kit_barcodes and fixes all SQL that was using it.