### PR TITLE
new feature: edit secondary survey

### DIFF
--- a/amgut/handlers/secondary_survey.py
+++ b/amgut/handlers/secondary_survey.py
@@ -33,6 +33,12 @@ class SecondarySurveyHandler(BaseHandler):
         form = survey_class()
         if survey_id:
             form.process(data=sec_survey.fetch_survey(survey_id))
+
+        # load existing information into the form
+        if survey_id != '':
+            data = sec_survey.fetch_survey(survey_id)
+            form = survey_class(data=data)
+
         self.render('secondary_survey.html', skid=skid,
                     the_form=form, survey_id=survey_id,
                     type=survey_type, participant_name=participant_name)

--- a/amgut/templates/participant_overview.html
+++ b/amgut/templates/participant_overview.html
@@ -45,12 +45,12 @@
 						</li>
 {% elif survey[0] == -3 %}
 	<!-- Fermented Food -->
-	<!--<a href="{% raw media_locale['SITEBASE'] %}/authed/secondary_survey/?type=fermented&participant_name={{participant_name}}&survey_id={{survey[1]}}">{{survey[2]}}</a><br/>-->
-						<li>{{survey[2]}} Survey</li>
+						<li><a href="{% raw media_locale['SITEBASE'] %}/authed/secondary_survey/?type=fermented&participant_name={{participant_name}}&survey={{survey[1]}}"><button>{{survey[2]}}</button></a></li>
+						<!--<li>{{survey[2]}} Survey</li>-->
 {% elif survey[0] == -4 %}
 	<!-- Surfer -->
-	<!--<a href="{% raw media_locale['SITEBASE'] %}/authed/secondary_survey/?type=surf&participant_name={{participant_name}}&survey_id={{survey[1]}}">{{survey[2]}}</a><br/>-->
-						<li>{{survey[2]}} Survey</li>
+						<li><a href="{% raw media_locale['SITEBASE'] %}/authed/secondary_survey/?type=surf&participant_name={{participant_name}}&survey={{survey[1]}}"><button>{{survey[2]}}</button></a></li>
+						<!--<li>{{survey[2]}} Survey</li>-->
 {% else %}
 						<li>{{survey[2]}} Survey</li>
 {% end %}


### PR DESCRIPTION
similar to the primary survey, a participant can now directly navigate to an earlier started secondary survey (surfer, fermented food) and edit his/her answers.