### PR TITLE
Remove dups

### DIFF
--- a/amgut/db/patches/0043.sql
+++ b/amgut/db/patches/0043.sql
@@ -1,0 +1,13 @@
+-- remove a duplicate survey_question_response_type entry created from patch 0033
+-- which appears to be a copy/pasta event from patch 0023, and add a constraint
+-- to ensure the entries of survey_question_response_type are unique.
+
+-- https://stackoverflow.com/questions/6583916/delete-completely-duplicate-rows-in-postgresql-and-keep-only-1
+DELETE FROM ag.survey_question_response_type a
+    WHERE a.ctid <> (SELECT min(b.ctid)
+    FROM   ag.survey_question_response_type b
+    WHERE  a.survey_question_id = b.survey_question_id);
+
+ALTER TABLE ag.survey_question_response_type 
+    ADD CONSTRAINT uc_survey_question_response_type 
+    UNIQUE (survey_question_id, survey_response_type);


### PR DESCRIPTION
Question 146, TYPES_OF_PLANTS, was duplicated stemming from what appears to be a copy/paste error between patch [0023](https://github.com/biocore/american-gut-web/blob/master/amgut/db/patches/0023.sql#L10) and [0033](https://github.com/biocore/american-gut-web/blob/master/amgut/db/patches/0033.sql#L19), where the problematic line was not deleted. The entry in patch 0033 does not appear to have relevance to the surrounding code. This patch removes the duplicate entry, and enforces a `UNIQUE` constraint on the table. 