### PR TITLE
addressing issue #679: Fermentation survey can be created multiple times

### DIFF
--- a/amgut/handlers/human_survey_completed.py
+++ b/amgut/handlers/human_survey_completed.py
@@ -17,7 +17,9 @@ class HumanSurveyCompletedHandler(BaseHandler):
 
         else:
             consent_info = ag_data.getConsent(human_survey_id)
-            surveys = [f(human_survey_id, consent_info)
+            internal_surveys = ag_data.get_participants_surveys(
+                consent_info['ag_login_id'], consent_info['participant_name'])
+            surveys = [f(human_survey_id, consent_info, internal_surveys)
                        for f in external_surveys]
 
             self.render('human_survey_completed.html', skid=self.current_user,

--- a/amgut/lib/util.py
+++ b/amgut/lib/util.py
@@ -128,7 +128,7 @@ def store_survey(survey, survey_id):
     survey.store_survey(consent_details, with_fk_inserts, without_fk_inserts)
 
 
-def survey_vioscreen(survey_id, consent_info):
+def survey_vioscreen(survey_id, consent_info, internal_surveys):
     """Return a formatted text block and URL for the external survey"""
     tl = text_locale['human_survey_completed.html']
     embedded_text = tl['SURVEY_VIOSCREEN']
@@ -137,7 +137,7 @@ def survey_vioscreen(survey_id, consent_info):
     return embedded_text % url
 
 
-def survey_asd(survey_id, consent_info):
+def survey_asd(survey_id, consent_info, internal_surveys):
     """Return a formatted text block and URL for the external survey"""
     tl = text_locale['human_survey_completed.html']
     url = media_locale['SURVEY_ASD_URL'] % {'survey_id': survey_id}
@@ -145,20 +145,38 @@ def survey_asd(survey_id, consent_info):
     return embedded_text % url
 
 
-def survey_fermented(survey_id, consent_info):
+def survey_fermented(survey_id, consent_info, internal_surveys):
     """Return a formatted text block and URL for the external survey"""
     tl = text_locale['human_survey_completed.html']
-    url = ('%s/authed/secondary_survey/?type=fermented&participant_name=%s' %
-           (media_locale['SITEBASE'], consent_info['participant_name']))
+    existing_surveys = [survey[1]
+                        for survey in internal_surveys
+                        # magic number for fermented food surveys is -3
+                        if (survey[0] == -3)]
+    if len(existing_surveys) > 0:
+        existing_surveys = '&survey=%s' % existing_surveys[0]
+    else:
+        existing_surveys = ''
+    url = ('%s/authed/secondary_survey/?type=fermented&participant_name=%s%s' %
+           (media_locale['SITEBASE'], consent_info['participant_name'],
+            existing_surveys))
     embedded_text = tl['SURVEY_FERMENTED']
     return embedded_text % url
 
 
-def survey_surf(survey_id, consent_info):
+def survey_surf(survey_id, consent_info, internal_surveys):
     """Return a formatted text block and URL for the external survey"""
     tl = text_locale['human_survey_completed.html']
-    url = ('%s/authed/secondary_survey/?type=surf&participant_name=%s' %
-           (media_locale['SITEBASE'], consent_info['participant_name']))
+    existing_surveys = [survey[1]
+                        for survey in internal_surveys
+                        # magic number for survers surveys is -4
+                        if (survey[0] == -4)]
+    if len(existing_surveys) > 0:
+        existing_surveys = '&survey=%s' % existing_surveys[0]
+    else:
+        existing_surveys = ''
+    url = ('%s/authed/secondary_survey/?type=surf&participant_name=%s%s' %
+           (media_locale['SITEBASE'], consent_info['participant_name'],
+            existing_surveys))
     embedded_text = tl['SURVEY_SURF']
     return embedded_text % url
 

--- a/amgut/lib/util.py
+++ b/amgut/lib/util.py
@@ -128,7 +128,7 @@ def store_survey(survey, survey_id):
     survey.store_survey(consent_details, with_fk_inserts, without_fk_inserts)
 
 
-def survey_vioscreen(survey_id, consent_info, internal_surveys):
+def survey_vioscreen(survey_id, consent_info, internal_surveys=[]):
     """Return a formatted text block and URL for the external survey"""
     tl = text_locale['human_survey_completed.html']
     embedded_text = tl['SURVEY_VIOSCREEN']
@@ -137,7 +137,7 @@ def survey_vioscreen(survey_id, consent_info, internal_surveys):
     return embedded_text % url
 
 
-def survey_asd(survey_id, consent_info, internal_surveys):
+def survey_asd(survey_id, consent_info, internal_surveys=[]):
     """Return a formatted text block and URL for the external survey"""
     tl = text_locale['human_survey_completed.html']
     url = media_locale['SURVEY_ASD_URL'] % {'survey_id': survey_id}
@@ -145,7 +145,7 @@ def survey_asd(survey_id, consent_info, internal_surveys):
     return embedded_text % url
 
 
-def survey_fermented(survey_id, consent_info, internal_surveys):
+def survey_fermented(survey_id, consent_info, internal_surveys=[]):
     """Return a formatted text block and URL for the external survey"""
     tl = text_locale['human_survey_completed.html']
     existing_surveys = [survey[1]
@@ -163,7 +163,7 @@ def survey_fermented(survey_id, consent_info, internal_surveys):
     return embedded_text % url
 
 
-def survey_surf(survey_id, consent_info, internal_surveys):
+def survey_surf(survey_id, consent_info, internal_surveys=[]):
     """Return a formatted text block and URL for the external survey"""
     tl = text_locale['human_survey_completed.html']
     existing_surveys = [survey[1]

--- a/amgut/test/test_human_survey_completed.py
+++ b/amgut/test/test_human_survey_completed.py
@@ -1,11 +1,11 @@
 from unittest import main
-import datetime
 from amgut.test.tornado_test_base import TestHandlerBase
 from amgut.connections import ag_data, redis
-from tornado import escape
-from amgut.lib.util import rollback, store_survey, make_survey_class
+from amgut.lib.util import rollback, store_survey
 from amgut.lib.data_access.survey import Survey
-from amgut.lib.survey_supp import (fermented_survey, surf_survey, personal_microbiome_survey)
+from amgut.lib.survey_supp import (fermented_survey,
+                                   surf_survey,
+                                   personal_microbiome_survey)
 from json import dumps
 
 

--- a/amgut/test/test_human_survey_completed.py
+++ b/amgut/test/test_human_survey_completed.py
@@ -1,0 +1,144 @@
+from unittest import main
+import datetime
+from amgut.test.tornado_test_base import TestHandlerBase
+from amgut.connections import ag_data, redis
+from tornado import escape
+from amgut.lib.util import rollback, store_survey, make_survey_class
+from amgut.lib.data_access.survey import Survey
+from amgut.lib.survey_supp import (fermented_survey, surf_survey, personal_microbiome_survey)
+from json import dumps
+
+
+class TestHumanSurveyCompleted(TestHandlerBase):
+    sec_surveys = {'fermented': fermented_survey,
+                   'surf': surf_survey,
+                   'personal_microbiome': personal_microbiome_survey}
+
+    @rollback
+    def test_edit_survey(self):
+        # creating a new participant for existing ag_login_id
+        main_survey_id = '38792874'
+        sec_survey_id_fermented = '3879287455'
+        sec_survey_id_surfer = '3879287456'
+        ag_login_id = 'd8592c74-9694-2135-e040-8a80115d6401'
+        participant_name = 'test_dude_stefan'
+        email = 'STEFAN@STEFAN.STEFAN'
+
+        with_fk_inserts =\
+            [(main_survey_id, _id, 'Unspecified') for _id in
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+                 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+                 50, 51, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65,
+                 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
+                 96, 107, 109, 110, 111, 112, 114, 146, 148, 149, 153, 154,
+                 155, 156, 157, 158, 159, 160, 162, 163, 164]]
+        without_fk_inserts =\
+            [(main_survey_id, _id, '[""]') for _id in
+                [98, 99, 150, 103, 104, 105, 106, 108, 113, 115, 116, 117, 118,
+                 119, 120, 122, 124, 126, 101]]
+        self.mock_login(ag_data.ut_get_supplied_kit_id(ag_login_id))
+
+        s = Survey(main_survey_id)
+        s.store_survey(
+            {u'login_id': ag_login_id,
+             u'age_range': u'18-plus',
+             u'parent_1_name': None,
+             u'participant_email': email,
+             u'obtainer_name': None,
+             u'parent_2_name': None,
+             u'deceased_parent': u'No',
+             u'participant_name': participant_name,
+             u'survey_id': main_survey_id,
+             u'is_juvenile': False},
+            with_fk_inserts, without_fk_inserts)
+
+        # confirm that no secondary surveys are present
+        response = self.post('/participants/%s' % participant_name,
+                             {'participant_type': 'human'})
+        self.assertEqual(response.code, 200)
+        self.assertNotIn('fermented', response.body)
+        self.assertNotIn('surf', response.body)
+
+        # add a new fermented food survey
+        data = {'questions': {'Fermented_Foods_170_0': [''],
+                              'Fermented_Foods_173_0': [''],
+                              'Fermented_Foods_169_0': None,
+                              'Fermented_Foods_171_0': ['13'],
+                              'Fermented_Foods_168_0': [''],
+                              'Fermented_Foods_167_0': ['1'],
+                              'Fermented_Foods_166_0': ['0'],
+                              'Fermented_Foods_165_0': ['0'],
+                              'Fermented_Foods_172_0': ['']}}
+        consent = {
+            'login_id': ag_login_id,
+            'participant_name': participant_name,
+            'survey_id': sec_survey_id_fermented,
+            'secondary': True
+        }
+        redis.hset(sec_survey_id_fermented, 'consent', dumps(consent))
+        redis.hset(sec_survey_id_fermented, 0, dumps(data))
+        redis.expire(sec_survey_id_fermented, 86400)
+        store_survey(fermented_survey, sec_survey_id_fermented)
+
+        # confirm that now a fermented food survey is present
+        response = self.post('/participants/%s' % participant_name,
+                             {'participant_type': 'human'})
+        self.assertEqual(response.code, 200)
+        self.assertIn('fermented', response.body)
+        self.assertNotIn('surf', response.body)
+        self.assertIn('secondary_survey/?type=%s&participant_name=%s&survey=%s'
+                      % ('fermented',
+                         participant_name,
+                         sec_survey_id_fermented), response.body)
+        # check human_survey_completed links:
+        # TODO: I don't know how to set a secured cookie for
+        # completed_survey_id and could need some help to actually test values
+        # for the rendered page /authed/human_survey_completed/
+        # response = self.get('/authed/human_survey_completed/')
+
+        # add a new surfers survey
+        data = {'questions': {'Surfers_182_0': ['0'],
+                              'Surfers_176_0': ['0'],
+                              'Surfers_175_0': ['0'],
+                              'Surfers_185_0': ['0'],
+                              'Surfers_179_0': ['0'],
+                              'Surfers_183_0': ['0'],
+                              'Surfers_180_0': ['0'],
+                              'Surfers_174_0': ['0'],
+                              'Surfers_178_0': ['0'],
+                              'Surfers_181_0': ['0'],
+                              'Surfers_177_0': ['0'],
+                              'Surfers_184_0': ['0']}}
+        consent = {
+            'login_id': ag_login_id,
+            'participant_name': participant_name,
+            'survey_id': sec_survey_id_surfer,
+            'secondary': True
+        }
+        redis.hset(sec_survey_id_surfer, 'consent', dumps(consent))
+        redis.hset(sec_survey_id_surfer, 0, dumps(data))
+        redis.expire(sec_survey_id_surfer, 86400)
+        store_survey(surf_survey, sec_survey_id_surfer)
+
+        # confirm that now a surfers and fermented food survey is present
+        response = self.post('/participants/%s' % participant_name,
+                             {'participant_type': 'human'})
+        self.assertEqual(response.code, 200)
+        self.assertIn('fermented', response.body)
+        self.assertIn('surf', response.body)
+        self.assertIn('secondary_survey/?type=%s&participant_name=%s&survey=%s'
+                      % ('fermented',
+                         participant_name,
+                         sec_survey_id_fermented),
+                      response.body)
+        self.assertIn('secondary_survey/?type=%s&participant_name=%s&survey=%s'
+                      % ('surf',
+                         participant_name,
+                         sec_survey_id_surfer),
+                      response.body)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I failed writing an appropriate unit test for this, because I don't know how to set a secured cookie in the unit test code and would need some help here.
Otherwise, I hope to have fixed the problem by passing the survery_id to the rendering methods, such that existing surveys should be edited to alternatively (if no survey of this type exists) a new survey is created. Please test manually.