### PR TITLE
nav to project before pip installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ Now by forking, clone and install the repository.  This will also install
 dependencies included in `extras_require`::
 
    git clone https://github.com/YOUR-GITHUB-USERNAME/american-gut-web.git
+   cd american-gut-web
    pip install -e .[test]
 
 And copy over the configuration file::


### PR DESCRIPTION
Quick fix as test PR - clone creates the repo directory, the user needs to nav into directory