### PR TITLE
Register kit rerender with previous details on invalid id/pw

### DIFF
--- a/amgut/handlers/auth_handlers.py
+++ b/amgut/handlers/auth_handlers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from tornado.web import authenticated
-from tornado.escape import jsone_encode
+from tornado.escape import json_encode
 import logging
 from collections import defaultdict
 

--- a/amgut/handlers/auth_handlers.py
+++ b/amgut/handlers/auth_handlers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from tornado.web import authenticated
+from tornado.escape import jsone_encode
 import logging
 from collections import defaultdict
 
@@ -49,8 +50,8 @@ class AuthRegisterHandoutHandler(AuthBasehandler):
                        'state': self.get_argument('state'),
                        'zip': self.get_argument('zip'),
                        'country': self.get_argument('country')}
-            self.render("register_user.html", kit_counts=kit_counts, 
-                        loginerror='', countries=countries,entries=entries)
+            self.render("register_user.html", kit_counts=kit_counts,
+                        loginerror='', countries=countries, entries=entries)
             return
 
         # Register handout

--- a/amgut/handlers/auth_handlers.py
+++ b/amgut/handlers/auth_handlers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from tornado.web import authenticated
-from tornado.escape import json_encode, url_escape
 import logging
 from collections import defaultdict
 
@@ -50,8 +49,8 @@ class AuthRegisterHandoutHandler(AuthBasehandler):
                        'state': self.get_argument('state'),
                        'zip': self.get_argument('zip'),
                        'country': self.get_argument('country')}
-            self.render("register_user.html", kit_counts=kit_counts,
-                         loginerror='', countries=countries,entries = entries)
+            self.render("register_user.html", kit_counts=kit_counts, 
+                        loginerror='', countries=countries,entries=entries)
             return
 
         # Register handout

--- a/amgut/handlers/auth_handlers.py
+++ b/amgut/handlers/auth_handlers.py
@@ -3,6 +3,7 @@
 from tornado.web import authenticated
 from tornado.escape import json_encode, url_escape
 import logging
+from collections import defaultdict
 
 from amgut.connections import ag_data
 from amgut.lib.mail import send_email
@@ -25,18 +26,32 @@ class AuthRegisterHandoutHandler(AuthBasehandler):
     def get(self):
         kit_counts = ag_data.getMapMarkers()
         countries = ag_data.get_countries()
-        self.render("register_user.html",
-                    kit_counts=kit_counts, loginerror='', countries=countries)
+
+        # defaults entries dict to be empty
+        entries = defaultdict(str)
+        self.render("register_user.html", kit_counts=kit_counts,
+                    loginerror='', countries=countries, entries=entries)
 
     def post(self):
         # Check handout
         skid = self.get_argument("kit_id").strip()
         password = self.get_argument("password")
+
         is_handout = ag_data.handoutCheck(skid, password)
         if not is_handout:
-            tl = text_locale['handlers']
-            self.redirect(media_locale['SITEBASE'] +
-                          "/?loginerror=" + url_escape(tl['INVALID_KITID']))
+            kit_counts = ag_data.getMapMarkers()
+            countries = ag_data.get_countries()
+            entries = {'kit_id': self.get_argument('kit_id'),
+                       'email': self.get_argument('email'),
+                       'email2': self.get_argument('email2'),
+                       'participantname': self.get_argument('participantname'),
+                       'address': self.get_argument('address'),
+                       'city': self.get_argument('city'),
+                       'state': self.get_argument('state'),
+                       'zip': self.get_argument('zip'),
+                       'country': self.get_argument('country')}
+            self.render("register_user.html", kit_counts=kit_counts,
+                         loginerror='', countries=countries,entries = entries)
             return
 
         # Register handout

--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -869,7 +869,7 @@ _REGISTER_USER = {
     'PASSWORD': 'Password',
     'KIT_ID': 'Kit ID',
     'SUBMIT': 'Submit My Information',
-    'INVALID_ID_OR_PW': "Invalid Kit ID or Password"
+    'INVALID_ID_OR_PW': "Invalid kit ID or password"
 }
 
 _ADDENDUM = {

--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -96,7 +96,6 @@ _HANDLERS = {
     'AUTH_REGISTER_PGP': "\n\nFor the PGP cohort, we are requesting that you collect one sample from each of the following sites:\n\nLeft hand\nRight hand\nForehead\nMouth\nFecal\n\nThis is important to ensure that we have the same types of samples for all PGP participants which, in turn, could be helpful in downstream analysis when looking for relationships between the microbiome and the human genome\n\n.",
     'AUTH_REGISTER_BODY': "Thank you for registering with the %(project_name)s! Your verification code is:\n\n{0}\n\nYou will need this code to verifiy your kit on the %(project_shorthand)s webstite. To get started, please log into:\n\nhttp://microbio.me/AmericanGut\n\nEnter the kit_id and password found inside your kit, verify the contents of your kit, and enter the verification code found in this email.{1}\n\nSincerely,\nThe %(project_shorthand)s Team" % {'project_shorthand': AMGUT_CONFIG.project_shorthand, 'project_name': AMGUT_CONFIG.project_name},
     'KIT_REG_SUCCESS': 'Kit registered successfully.',
-    'INVALID_KITID': "Invalid Kit ID or Password",
     'ADD_KIT_ERROR': "Could not add kit to database.  Did you hit the back button while registering and press 'register user' again?",
     'ADD_BARCODE_ERROR': "Could not add barcode to database. Did you hit the back button while registering and press 'register user' again?",
     'CHANGE_PASS_BODY': 'This is a courtesy email to confirm that you have changed your password for your kit with ID %s. If you did not request this change, please email us immediately at {0}'.format(media_locale['HELP_EMAIL']),
@@ -869,7 +868,8 @@ _REGISTER_USER = {
     'COUNTRY': 'Country',
     'PASSWORD': 'Password',
     'KIT_ID': 'Kit ID',
-    'SUBMIT': 'Submit My Information'
+    'SUBMIT': 'Submit My Information',
+    'INVALID_ID_OR_PW': "Invalid Kit ID or Password"
 }
 
 _ADDENDUM = {

--- a/amgut/lib/locale_data/british_gut.py
+++ b/amgut/lib/locale_data/british_gut.py
@@ -797,7 +797,7 @@ _REGISTER_USER = {
     'SUBMIT': "Submit My Information",
     'ZIP': "Postcode",
     'KIT_ID': 'Kit ID',
-    'INVALID_ID_OR_PW': "Invalid Kit ID or Password"
+    'INVALID_ID_OR_PW': "Invalid kit ID or password"
 }
 
 _ADDENDUM = {

--- a/amgut/lib/locale_data/british_gut.py
+++ b/amgut/lib/locale_data/british_gut.py
@@ -796,7 +796,8 @@ _REGISTER_USER = {
     'PASSWORD': 'Password',
     'SUBMIT': "Submit My Information",
     'ZIP': "Postcode",
-    'KIT_ID': 'Kit ID'
+    'KIT_ID': 'Kit ID',
+    'INVALID_ID_OR_PW': "Invalid Kit ID or Password"
 }
 
 _ADDENDUM = {

--- a/amgut/templates/register_user.html
+++ b/amgut/templates/register_user.html
@@ -83,24 +83,31 @@ $(document).ready(function() {
 {% block content %}
 {% from amgut import text_locale %}
 {% set tl = text_locale['register_user.html'] %}
+{% set e = entries %}
 <div class="registerwrapper" style="position:absolute; left:285px; padding:15px;">
     <form name="newParticipant" id="newParticipant" method="post" action="{% raw media_locale['SITEBASE'] %}/auth/register/">
         <h3>New User Registration</h3>
+        {% if e['kit_id'] %}
+            <p style="color:red">{{tl['INVALID_ID_OR_PW']}}</p>
+        {% end %}
         <table>
-            <tr><td>{% raw tl['KIT_ID'] %}</td><td><input type="text" name="kit_id" id="kit_id"></td></tr>
+            <tr><td>{% raw tl['KIT_ID'] %}</td><td><input type="text" name="kit_id" id="kit_id" value={{e['kit_id']}}></td></tr>
             <tr><td>{% raw tl['PASSWORD'] %}</td><td><input type="password" name="password" id="password"></td></tr>
-            <tr><td>{% raw tl['EMAIL'] %}</td><td><input type="text" name="email" id="email"></td></tr>
-            <tr><td>{% raw tl['EMAIL2'] %}</td><td><input type="text" name="email2" id="email2"></td></tr>
-            <tr><td>{% raw tl['NAME'] %}</td><td><input type="text" name="participantname" id="participantname"></td></tr>
-            <tr><td>{% raw tl['ADDRESS'] %}</td><td><input type="text" name="address" id="address"></td></tr>
-            <tr><td>{% raw tl['CITY'] %}</td><td><input type="text" name="city" id="city"></td></tr>
-            <tr><td>{% raw tl['STATE'] %}</td><td><input type="text" name="state" id="state"></td></tr>
-            <tr><td>{% raw tl['ZIP'] %}</td><td><input type="text" name="zip" id="zip"></td></tr>
+            <tr><td>{% raw tl['EMAIL'] %}</td><td><input type="text" name="email" id="email" value={{e['email']}}></td></tr>
+            <tr><td>{% raw tl['EMAIL2'] %}</td><td><input type="text" name="email2" id="email2" value={{e['email2']}}></td></tr>
+            <tr><td>{% raw tl['NAME'] %}</td><td><input type="text" name="participantname" id="participantname" value={{e['participantname']}}></td></tr>
+            <tr><td>{% raw tl['ADDRESS'] %}</td><td><input type="text" name="address" id="address" value={{e['address']}}></td></tr>
+            <tr><td>{% raw tl['CITY'] %}</td><td><input type="text" name="city" id="city" value={{e['city']}}></td></tr>
+            <tr><td>{% raw tl['STATE'] %}</td><td><input type="text" name="state" id="state" value={{e['state']}}></td></tr>
+            <tr><td>{% raw tl['ZIP'] %}</td><td><input type="text" name="zip" id="zip" value={{e['zip']}}></td></tr>
             <tr><td>{% raw tl['COUNTRY'] %}</td><td>
               <select name="country" id="country" class="chosen-dropdown">
               <option value=''></option>
               {% for country in countries %}
                 <option value='{{country}}'>{{country}}</option>
+              {% end %}
+              {% if e['country'] %}
+                <option selected='{{e['country']}}'>{{e['country']}}</option>
               {% end %}
               </select>
             </td></tr>


### PR DESCRIPTION
Now should rerender with an error message and previous statements when submitting all entries with an invalid id or pw instead of returning to home page.