### PR TITLE
Message for dupe survey and fixed animal dupe

### DIFF
--- a/amgut/handlers/animal_survey.py
+++ b/amgut/handlers/animal_survey.py
@@ -49,7 +49,7 @@ class AnimalSurveyHandler(BaseHandler):
         data = {'questions': form.data}
         participant_name = form['Pet_Information_127_0'].data[0]
         # If the participant already exists, stop them outright
-        if not animal_survey_id and \
+        if new_survey and \
                 ag_data.check_if_consent_exists(ag_login_id, participant_name):
             errmsg = url_escape(tl['PARTICIPANT_EXISTS'] % participant_name)
             url = sitebase + "/authed/portal/?errmsg=%s" % errmsg

--- a/amgut/lib/locale_data/american_gut.py
+++ b/amgut/lib/locale_data/american_gut.py
@@ -88,7 +88,7 @@ media_locale = {
 
 
 _HANDLERS = {
-    'PARTICIPANT_EXISTS': 'Participant %s already exists!',
+    'PARTICIPANT_EXISTS': 'Participant %s already exists! This means we already have a survey on file under this name. Try using a variation of the name (such as substituting an initial for the first or last name).',
     'MISSING_NAME_EMAIL': 'Missing participant name or email. Please retry, adding all required information.',
     'SUCCESSFULLY_ADDED': "Successfully added %s!",
     'SUCCESSFULLY_EDITED': "Successfully edited %s!",

--- a/amgut/lib/locale_data/british_gut.py
+++ b/amgut/lib/locale_data/british_gut.py
@@ -88,7 +88,7 @@ media_locale = {
 }
 
 _HANDLERS = {
-    'PARTICIPANT_EXISTS': 'Participant %s already exists!',
+    'PARTICIPANT_EXISTS': 'Participant %s already exists! This means we already have a survey on file under this name. Try using a variation of the name (such as substituting an initial for the first or last name).',
     'SUCCESSFULLY_ADDED': "Successfully added %s!",
     'SUCCESSFULLY_EDITED': "Successfully edited %s!",
     'MISSING_NAME_EMAIL': 'Missing participant name or email. Please retry, adding all required information.',


### PR DESCRIPTION
Added a message for duplicate human surveys based on Dom's suggestion 

In some cases, participants create a new survey and try to use their same name. They receive a message saying “Participant ______ Already Exists”, so they get baffled as to why this happens
Would be useful to include a message that maybe says:
“This means that we already have a survey on file under this name.  Our system doesn’t recognize if you try to create a new participant profile under this exact spelling--if you would like to create a new profile for yourself, try using a variation of your name (such as using an initial for your first or last name)”

Animal survey's weren't working for duplicate surveys so I fixed an inconsistency in the animal survey handler to make it consistent with human survey dupes.