### PR TITLE
MAINT: remove interactive action as it isn't hooked up yet

### DIFF
--- a/amgut/templates/sample_overview.html
+++ b/amgut/templates/sample_overview.html
@@ -45,7 +45,8 @@
                 <td>{% raw tl['SAMPLE_NOT_PROCESSED'] %}</td>
 {% end %}
 	        </tr>
-            <tr>
+<!--            
+                <tr>
                 <td>{% raw tl['INTERACTIVE_REPORT_TITLE'] %}</td>
 {% if barcode_txt %}
                 <td>
@@ -58,6 +59,7 @@
 {% end %}
 
             </tr>
+-->
             <tr>
                 <td style="width: 150px;">{% raw tl['SAMPLE_STATUS'] %}</td>
                 <td>{{ status }}</td>


### PR DESCRIPTION
Temporarily remove the interactive report button as it isn't hooked up to anything yet. This is being commented out as this is a last fix before going live, and the intention is to restore as is. 