### PR TITLE
Open bill of rights links in new tab/window

### DIFF
--- a/amgut/templates/new_participant.html
+++ b/amgut/templates/new_participant.html
@@ -137,7 +137,7 @@
 </div>
     <div class="" id="consent">
         <hr>
-        <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
+        <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
         <form method="post" id="0-6-form" name="consent_info" onsubmit="return validate06();" action="{% raw media_locale['SITEBASE'] %}/authed/new_participant/">
            <input type="hidden" name="age_range" value="0-6">
            <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {% raw tl['TEXT_I_HAVE_READ_PARENT'] %}</p>
@@ -181,7 +181,7 @@
 </div>
 <div class="" id="consent">
         <hr>
-            <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
+            <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
            <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {% raw tl['TEXT_I_HAVE_READ_PARENT'] %}</p>
     </div>
     <table>
@@ -215,7 +215,7 @@
     </div>
     <div class="" id="consent">
         <hr>
-        <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
+        <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
            <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {% raw tl['TEXT_I_HAVE_READ_PARENT'] %}</p>
     </div>
     <table>
@@ -235,7 +235,7 @@
 </div>
 <div class="" id="consent">
         <hr>
-        <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
+        <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{% raw tl['BILL_OF_RIGHTS']%}</a><br/>
         <form method="post" id="18-form" name="consent_info" onsubmit="return min_validation('18-form');" action="{% raw media_locale['SITEBASE'] %}/authed/new_participant/">
         <input type="hidden" name="age_range" value="18-plus">
            <p><input value="Yes" type="checkbox" name="consent" id="consent" required data-rule-required="true"> {% raw tl['TEXT_I_HAVE_READ_1'] %}</p>


### PR DESCRIPTION
When the bill of rights PDF opens in the same tab/window, the user has to navigate "back" to return to the new participant page. However, when the user returns to the page, the containers of the consent/assent forms are kept closed and the radio button for age selection is kept selected -- which means the user has to manually select another age and then select the correct age option in order to re-open the correct consent/assent forms.

This is a partial fix for this problem, since it should make the bill of rights PDF open in a new tab or window (preserving the context of the original page). However, I think it'd also be a good idea to fix the problem of the consent/assent containers automatically closing in the future, in case the user ends up navigating back to this page anyway (due to either clicking a link in the sidebar, or their browser not recognizing `target="_blank"` for the bill of rights PDF).